### PR TITLE
change chromatic project token

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,7 +15,7 @@ jobs:
         yarn build-storybook
     - uses: chromaui/action@v1
       with: 
-        appCode: 9ofhn0iql7n
+        appCode: please create a new project on chromatic
         token: ${{ secrets.GITHUB_TOKEN }}
         storybookBuildDir: storybook-static
         


### PR DESCRIPTION
You're using a project token for chromatic on someone else's project.

Could you please disable or change the project token?