### PR TITLE
change binary verification to resolve helpertext bug

### DIFF
--- a/src/packages/ui-components/Forms/Text/index.tsx
+++ b/src/packages/ui-components/Forms/Text/index.tsx
@@ -151,7 +151,7 @@ const TextField = React.forwardRef<React.LegacyRef<HTMLInputElement>, ITextField
           error={hasError}
           {...props}
           disabled={form?.isSubmitting || props.disabled || loading}
-          helperText={errorMessage ?? props.helperText}
+          helperText={errorMessage || props.helperText}
           name={name}
           margin={margin ?? 'normal'}
           variant='outlined'


### PR DESCRIPTION
Mudança do verificador ?? para ||, pois quando na props helperText ele verifica se há erro, se esse erro for uma string vazia ele já identifica que é um valor válido, então não mostra o valor que foi passado na props.