### PR TITLE
docs(houston-ui): Adiciona licensa do MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Eduzz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Salve Guys
Estou adicionando uma licença do MIT no Houston, pois não possuir licença, pode dar problemas para quem está usando a biblioteca (pois é kk), como existem outros projetos que não são da Eduzz utilizando o Houston, acho válido colocar isso o mais rápido possível.
O fato de um projeto não ter licença significa que os usuário que usam o Houston hoje não tem permissão nossa para usar, modificar ou compartilhar o software. Caso não saibam o por que de ter uma licença [este site](https://choosealicense.com/no-permission/) explica melhor isso.
Se quiserem debater depois sobre qual licença usar, acho que podemos discutir isso depois, antes acho válido colocar a do MIT por que ela é curta e direta.