### PR TITLE
Ajustes na Sidebar

### DIFF
--- a/src/pages/ui-components/Layout/Content/index.tsx
+++ b/src/pages/ui-components/Layout/Content/index.tsx
@@ -12,4 +12,6 @@ const SidebarContent: React.FC<ISidebarContentProps> = ({ ...rest }) => {
 
 export default styled(SidebarContent, { label: 'houston-sidebar-content' })`
   flex: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
 `;

--- a/src/pages/ui-components/Layout/Sidebar/Sidebar.tsx
+++ b/src/pages/ui-components/Layout/Sidebar/Sidebar.tsx
@@ -24,7 +24,7 @@ export interface ISidebarProps {
   /**
    * Mobile display control.
    */
-  mobileVisible: boolean;
+  mobileVisible?: boolean;
   /**
    * Function called when click in outside element on mobile.
    */
@@ -34,6 +34,7 @@ export interface ISidebarProps {
    * Whether can be collapsed.
    */
   collapsible?: boolean;
+  initialCollapsed?: boolean;
   onCollapse?: (collapsed: boolean) => void;
   children: React.ReactNode;
 }
@@ -42,15 +43,16 @@ const Sidebar: React.FC<ISidebarProps> = ({
   currentLocation,
   hasToolbar = true,
   children,
-  mobileVisible,
+  mobileVisible = false,
   onRequestClose,
   onCollapse,
-  collapsed: collapsedProp = false,
+  initialCollapsed,
+  collapsed: collapsedProp,
   collapsible = true,
   ...rest
 }) => {
   const [insideComponent, , setInsideComponentTrue, setInsideComponentFalse] = useBoolean(false);
-  const [collapsed, setCollapsed] = React.useState(collapsedProp ?? false);
+  const [collapsed, setCollapsed] = React.useState(initialCollapsed ?? false);
 
   const handleCollapse = React.useCallback(() => {
     setCollapsed(v => {
@@ -67,7 +69,7 @@ const Sidebar: React.FC<ISidebarProps> = ({
       hasToolbar,
       onRequestClose,
       mobileVisible,
-      collapsed,
+      collapsed: collapsedProp !== undefined ? collapsedProp : collapsed,
       collapsible,
       handleCollapse,
       insideComponent,
@@ -78,13 +80,14 @@ const Sidebar: React.FC<ISidebarProps> = ({
       currentLocation,
       hasToolbar,
       onRequestClose,
+      mobileVisible,
+      collapsedProp,
       collapsed,
       collapsible,
       handleCollapse,
       insideComponent,
-      mobileVisible,
-      setInsideComponentFalse,
-      setInsideComponentTrue
+      setInsideComponentTrue,
+      setInsideComponentFalse
     ]
   );
 

--- a/src/pages/ui-components/Layout/index.mdx
+++ b/src/pages/ui-components/Layout/index.mdx
@@ -95,17 +95,53 @@ const { Logo, Menu, MenuItem, SubMenuItem } = Sidebar;
 </Layout>
 ```
 
+### Controlável
+
+Há possibilidade de você controlar quando a Sidebar é recolhida/expandida.
+
+```jsx
+import Layout from '@eduzz/houston-ui/Layout';
+import Button from '@eduzz/houston-ui/Button';
+
+const { Sidebar, Content } = Layout;
+const { Logo, Menu, MenuItem, SubMenuItem } = Sidebar;
+
+function CustomLayout() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  function toggle() {
+    setCollapsed(state => !state)
+  }
+
+  return (
+    <Layout>
+      <Sidebar collapsed={collapsed} onCollapse={toggle}>
+        {...}
+      </Sidebar>
+
+      <Content>
+        <Button onClick={toggle}>Toggle collapsed</Button>
+        {...}
+      </Content>
+    </Layout>
+  );
+}
+
+export default CustomLayout;
+```
+
 ### Sidebar props
 
-| prop            | tipo       | obrigatório | padrão  | descrição                                               |
-| --------------- | ---------- | ----------- | ------- | ------------------------------------------------------- |
-| currentLocation | `string`   | `false`     | -       | Caminho de localização atual (pathname).                |
-| hasToolbar      | `boolean`  | `false`     | `true`  | Aplica uma margem à parte superior da Sidebar.          |
-| mobileVisible   | `boolean`  | `true`      | `false` | Controle de exibição no mobile.                         |
-| onRequestClose  | `function` | `false`     | `false` | Função chamada ao clicar no elemento externo no mobile. |
-| collapsed       | `boolean`  | `false`     | `false` | -                                                       |
-| collapsible     | `boolean`  | `false`     | `true`  | -                                                       |
-| onCollapse      | `function` | `false`     | -       | -                                                       |
+| prop             | tipo       | obrigatório | padrão  | descrição                                                           |
+| ---------------- | ---------- | ----------- | ------- | ------------------------------------------------------------------- |
+| currentLocation  | `string`   | `false`     | -       | Caminho de localização atual (pathname).                            |
+| hasToolbar       | `boolean`  | `false`     | `true`  | Aplica uma margem à parte superior da Sidebar.                      |
+| mobileVisible    | `boolean`  | `true`      | `false` | Controle de exibição no mobile.                                     |
+| onRequestClose   | `function` | `false`     | `false` | Função chamada ao clicar no elemento externo no mobile.             |
+| collapsed        | `boolean`  | `false`     | `false` | Se preenchido, você deve controlar quando será recolhido/expandido. |
+| initialCollapsed | `boolean`  | `false`     | `false` | -                                                                   |
+| collapsible      | `boolean`  | `false`     | `true`  | -                                                                   |
+| onCollapse       | `function` | `false`     | -       | -                                                                   |
 
 ### Sidebar.Logo props
 

--- a/src/pages/ui-components/Table/Pagination/index.tsx
+++ b/src/pages/ui-components/Table/Pagination/index.tsx
@@ -119,7 +119,7 @@ const Pagination = React.memo<ITablePagination>(
       <tfoot className={className}>
         <tr>
           <td colSpan={1000} className='__td'>
-            <Container>
+            <Container layout='fluid'>
               <Row>
                 <Column xs={12} sm='auto'>
                   <Row justifyContent='center'>


### PR DESCRIPTION
Havia um bug onde não era possível controlar a prop `collapsed` corretamente.

Agora, quando preenchido a prop `collapsed` o usuário é forçado a controlar o estado de recolher/expandir a Sidebar (pelas props `collapsed` e `onCollapse`).

Adicionei a prop `initialCollapsed` para controlar o estado inicial (quando não preenchido a prop `collapsed`).

Atualizei nossa documentação exemplificando o caso.