### PR TITLE
Adiciona componente Thumbnail

### DIFF
--- a/src/pages/ui-components/Thumbnail/index.mdx
+++ b/src/pages/ui-components/Thumbnail/index.mdx
@@ -53,7 +53,7 @@ import Thumbnail from '@eduzz/houston-ui/Thumbnail';
 
 ## Propriedades
 
-Fora as propriedades criadas por nós, possui todas propriedades de uma tag `<img />` comum.
+Possui todas propriedades de uma tag `<img />` comum.
 
 | prop        | tipo                                               | obrigatório | padrão | descrição                                                                                                                                  |
 | ----------- | -------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/src/pages/ui-components/Thumbnail/index.mdx
+++ b/src/pages/ui-components/Thumbnail/index.mdx
@@ -1,0 +1,63 @@
+---
+name: Thumbnail
+---
+
+import { Playground } from 'dokz';
+
+import Caption from '../Typography/Caption';
+import Thumbnail from './';
+
+# Thumbnail
+
+As thumbnails são versões reduzidas de imagens, usadas para tornar mais fácil o processo de procura, localização e reconhecimento.
+
+### Importação
+
+```js
+import Thumbnail from '@eduzz/houston-ui/Thumbnail';
+```
+
+### Tamanhos
+
+<Playground>
+  <div style={{ display: 'flex', gap: 16, alignItems: 'flex-end', textAlign: 'center' }}>
+    <figure>
+      <Thumbnail src='https://picsum.photos/80' size='xl' />
+      <Caption>xl</Caption>
+    </figure>
+    <figure>
+      <Thumbnail src='https://picsum.photos/80' size='lg' />
+      <Caption>lg</Caption>
+    </figure>
+    <figure>
+      <Thumbnail src='https://picsum.photos/80' size='md' />
+      <Caption>md</Caption>
+    </figure>
+    <figure>
+      <Thumbnail src='https://picsum.photos/80' size='sm' />
+      <Caption>sm</Caption>
+    </figure>
+  </div>
+</Playground>
+
+### Fallback
+
+<Playground>
+  <div style={{ display: 'flex', gap: 16, alignItems: 'flex-end' }}>
+    <Thumbnail src='https://via.placeholder.com/80' size='xl' />
+    <Thumbnail src='https://via.placeholder.com/64' size='lg' />
+    <Thumbnail src='https://via.placeholder.com/40' size='md' />
+    <Thumbnail src='https://via.placeholder.com/24' size='sm' />
+  </div>
+</Playground>
+
+## Propriedades
+
+Fora as propriedades criadas por nós, possui todas propriedades de uma tag `<img />` comum.
+
+| prop        | tipo                                               | obrigatório | padrão | descrição                                                                                                                                  |
+| ----------- | -------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| src         | `string`                                           | `true`      | -      | Caminho da imagem.                                                                                                                         |
+| fallbackSrc | `string`                                           | `false`     | -      | Caminho para imagem quando a imagem principal não estiver carregada ou não carregar. É recomendável usar um caminho para uma imagem local. |
+| fit         | `'fill', 'contain', 'cover', 'none', 'scale-down'` | `false`     | -      | -                                                                                                                                          |
+| size        | `'sm', 'md', 'lg', 'xl'`                           | `false`     | `md`   | -                                                                                                                                          |

--- a/src/pages/ui-components/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Thumbnail/index.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+import styled, { css, cx } from '@eduzz/houston-styles';
+
+export type ThumbnailSizes = 'sm' | 'md' | 'lg' | 'xl';
+export type ThumbnailFits = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+
+export interface IThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  fallbackSrc?: string;
+  size: ThumbnailSizes;
+  src: string;
+  fit?: ThumbnailFits;
+}
+
+const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
+  ({ fallbackSrc, src: srcProp, size, className, fit, ...props }, ref) => {
+    const [src, setSrc] = React.useState(fallbackSrc || srcProp);
+
+    React.useEffect(() => {
+      if (!fallbackSrc) return;
+      const image = new Image();
+      image.src = srcProp;
+      image.onload = () => setSrc(srcProp);
+    }, [srcProp, fallbackSrc]);
+
+    return (
+      <img
+        ref={ref}
+        className={cx(
+          className,
+          {
+            '--xlarge': size === 'xl',
+            '--large': size === 'lg',
+            '--medium': size === 'md',
+            '--small': size === 'sm'
+          },
+          fit && `--${fit}`
+        )}
+        src={src}
+        {...props}
+      />
+    );
+  }
+);
+
+export default styled(Thumbnail, { label: 'houston-thumbnail' })`
+  ${({ theme }) => css`
+    border-radius: ${theme.pxToRem(theme.border.radius.xs)};
+
+    &.--xlarge {
+      width: ${theme.pxToRem('80px')};
+      height: ${theme.pxToRem('80px')};
+    }
+
+    &.--large {
+      width: ${theme.pxToRem('64px')};
+      height: ${theme.pxToRem('64px')};
+    }
+
+    &.--medium {
+      width: ${theme.pxToRem('40px')};
+      height: ${theme.pxToRem('40px')};
+    }
+
+    &.--small {
+      width: ${theme.pxToRem('24px')};
+      height: ${theme.pxToRem('24px')};
+    }
+
+    &.--fill {
+      object-fit: fill;
+    }
+
+    &.--contain {
+      object-fit: contain;
+    }
+
+    &.--cover {
+      object-fit: cover;
+    }
+
+    &.--none {
+      object-fit: none;
+    }
+
+    &.--scale-down {
+      object-fit: scale-down;
+    }
+  `}
+`;

--- a/src/pages/ui-components/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Thumbnail/index.tsx
@@ -12,11 +12,14 @@ export interface IThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElemen
    */
   size?: ThumbnailSizes;
   src: string;
+  /**
+   * Default `cover`
+   */
   fit?: ThumbnailFits;
 }
 
 const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
-  ({ fallbackSrc, src: srcProp, size = 'md', className, fit, ...props }, ref) => {
+  ({ fallbackSrc, src: srcProp, size = 'md', className, fit = 'cover', ...props }, ref) => {
     const [src, setSrc] = React.useState(fallbackSrc || srcProp);
 
     React.useEffect(() => {
@@ -34,7 +37,7 @@ const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
           '--large': size === 'lg',
           '--medium': size === 'md',
           '--small': size === 'sm',
-          [`--${fit}`]: !!fit
+          [`--fit-${fit}`]: !!fit
         })}
         src={src}
         {...props}

--- a/src/pages/ui-components/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Thumbnail/index.tsx
@@ -7,13 +7,16 @@ export type ThumbnailFits = 'fill' | 'contain' | 'cover' | 'none' | 'scale-down'
 
 export interface IThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   fallbackSrc?: string;
-  size: ThumbnailSizes;
+  /**
+   * Default `md`
+   */
+  size?: ThumbnailSizes;
   src: string;
   fit?: ThumbnailFits;
 }
 
 const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
-  ({ fallbackSrc, src: srcProp, size, className, fit, ...props }, ref) => {
+  ({ fallbackSrc, src: srcProp, size = 'md', className, fit, ...props }, ref) => {
     const [src, setSrc] = React.useState(fallbackSrc || srcProp);
 
     React.useEffect(() => {

--- a/src/pages/ui-components/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Thumbnail/index.tsx
@@ -29,16 +29,13 @@ const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
     return (
       <img
         ref={ref}
-        className={cx(
-          className,
-          {
-            '--xlarge': size === 'xl',
-            '--large': size === 'lg',
-            '--medium': size === 'md',
-            '--small': size === 'sm'
-          },
-          fit && `--${fit}`
-        )}
+        className={cx(className, {
+          '--xlarge': size === 'xl',
+          '--large': size === 'lg',
+          '--medium': size === 'md',
+          '--small': size === 'sm',
+          [`--${fit}`]: !!fit
+        })}
         src={src}
         {...props}
       />
@@ -70,23 +67,23 @@ export default styled(Thumbnail, { label: 'houston-thumbnail' })`
       height: ${theme.pxToRem('24px')};
     }
 
-    &.--fill {
+    &.--fit-fill {
       object-fit: fill;
     }
 
-    &.--contain {
+    &.--fit-contain {
       object-fit: contain;
     }
 
-    &.--cover {
+    &.--fit-cover {
       object-fit: cover;
     }
 
-    &.--none {
+    &.--fit-none {
       object-fit: none;
     }
 
-    &.--scale-down {
+    &.--fit-scale-down {
       object-fit: scale-down;
     }
   `}

--- a/src/pages/ui-components/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Thumbnail/index.tsx
@@ -29,20 +29,7 @@ const Thumbnail = React.forwardRef<HTMLImageElement, IThumbnailProps>(
       image.onload = () => setSrc(srcProp);
     }, [srcProp, fallbackSrc]);
 
-    return (
-      <img
-        ref={ref}
-        className={cx(className, {
-          '--xlarge': size === 'xl',
-          '--large': size === 'lg',
-          '--medium': size === 'md',
-          '--small': size === 'sm',
-          [`--fit-${fit}`]: !!fit
-        })}
-        src={src}
-        {...props}
-      />
-    );
+    return <img ref={ref} className={cx(className, size && `--${size}`, fit && `--fit-${fit}`)} src={src} {...props} />;
   }
 );
 
@@ -50,22 +37,22 @@ export default styled(Thumbnail, { label: 'houston-thumbnail' })`
   ${({ theme }) => css`
     border-radius: ${theme.pxToRem(theme.border.radius.xs)};
 
-    &.--xlarge {
+    &.--xl {
       width: ${theme.pxToRem('80px')};
       height: ${theme.pxToRem('80px')};
     }
 
-    &.--large {
+    &.--lg {
       width: ${theme.pxToRem('64px')};
       height: ${theme.pxToRem('64px')};
     }
 
-    &.--medium {
+    &.--md {
       width: ${theme.pxToRem('40px')};
       height: ${theme.pxToRem('40px')};
     }
 
-    &.--small {
+    &.--sm {
       width: ${theme.pxToRem('24px')};
       height: ${theme.pxToRem('24px')};
     }


### PR DESCRIPTION
Galera, criei o componente Thumbnail, também tomei liberdade para tomar algumas decisões:

- Defini o tamanho padrão para medium, já que no Avatar está como medium também;
- Adicionei uma prop chamada fallbackSrc para que o usuário possa informar uma imagem enquanto a principal não está carregada ou se houve algum problema no carregamento.
- Inclui uma prop chamada fit porque dependendo do contexto o `object-fit` de uma imagem é muito necessário, principalmente no nosso caso que o aspect ratio é apenas de 1:1;

Concordam com esses pontos? Adicionaria ou removeria algo? Comentem <3

Preview: 
![image](https://user-images.githubusercontent.com/58918493/168615400-6c701a9a-8b83-4f32-8add-3eb25d8134f6.png)
