### PR TITLE
Atualiza componente Typography/Heading

### DIFF
--- a/src/pages/ui-components/Typography/Heading/index.tsx
+++ b/src/pages/ui-components/Typography/Heading/index.tsx
@@ -31,11 +31,13 @@ export interface IHeadingProps extends IStyledProp {
   ['aria-label']?: string;
 }
 
-type SizesMap = {
-  [key in HeadingTags | HeadingSizes]: keyof HoustonTokens['font']['size'];
+type FontProps = 'size' | 'weight';
+
+type FontPropMap<P extends FontProps> = {
+  [key in HeadingTags | HeadingSizes]: keyof HoustonTokens['font'][P];
 };
 
-const defaultSizesMap: SizesMap = {
+const defaultSizesMap: FontPropMap<'size'> = {
   h1: 'giant',
   h2: 'xxxl',
   h3: 'xxl',
@@ -50,7 +52,7 @@ const defaultSizesMap: SizesMap = {
   xs: 'xs'
 };
 
-const mobileSizesMap: SizesMap = {
+const mobileSizesMap: FontPropMap<'size'> = {
   h1: 'xxxl',
   h2: 'xxl',
   h3: 'lg',
@@ -65,14 +67,30 @@ const mobileSizesMap: SizesMap = {
   xs: 'xs'
 };
 
+const weightsMap: FontPropMap<'weight'> = {
+  h1: 'regular',
+  h2: 'regular',
+  h3: 'semibold',
+  h4: 'semibold',
+  h5: 'semibold',
+  h6: 'bold',
+  display: 'regular',
+  xl: 'regular',
+  lg: 'semibold',
+  md: 'semibold',
+  sm: 'semibold',
+  xs: 'bold'
+};
+
 const Heading = React.forwardRef<HTMLHeadingElement, IHeadingProps>(
   ({ as = 'h1', children, size: sizeProp, ...props }, ref) => {
     const { breakpoints } = useHoustonTheme();
     const isMobile = useMediaQuery(breakpoints.down('sm'));
     const sizesMap = isMobile ? mobileSizesMap : defaultSizesMap;
     const fontSize = sizeProp ? sizesMap[sizeProp] : sizesMap[as];
+    const fontWeight = sizeProp ? weightsMap[sizeProp] : weightsMap[as];
     return (
-      <Typography as={as} ref={ref} size={fontSize} weight='bold' {...props}>
+      <Typography as={as} ref={ref} size={fontSize} weight={fontWeight} {...props}>
         {children}
       </Typography>
     );

--- a/src/pages/ui-components/Typography/index.tsx
+++ b/src/pages/ui-components/Typography/index.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import styled, { css, IStyledProp } from '@eduzz/houston-styles/styled';
+import styled, { css, cx, IStyledProp } from '@eduzz/houston-styles/styled';
 import type { HoustonTokens } from '@eduzz/houston-tokens';
-
-import getColorFallback from '../utils/getColorFallback';
 
 export type TypographyColors = 'low' | 'high' | 'primary';
 
@@ -27,9 +25,33 @@ export interface ITypographyProps extends IStyledProp {
 }
 
 const Typography = React.forwardRef<any, ITypographyProps>(
-  ({ as: Tag = 'p', children, color = 'low', ...props }, ref) => {
+  (
+    {
+      as: Tag = 'p',
+      children,
+      size = 'xs',
+      weight = 'regular',
+      lineHeight = 'md',
+      marginBottom,
+      color = 'low',
+      className,
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <Tag ref={ref} color={color} {...props}>
+      <Tag
+        ref={ref}
+        className={cx(
+          className,
+          `--size-${size}`,
+          `--weight-${weight}`,
+          `--line-height-${lineHeight}`,
+          `--color-${color}`,
+          !!marginBottom && '--margin-bottom'
+        )}
+        {...props}
+      >
         {children}
       </Tag>
     );
@@ -37,13 +59,48 @@ const Typography = React.forwardRef<any, ITypographyProps>(
 );
 
 export default styled(Typography)`
-  ${({ theme, size = 'xs', weight = 'regular', lineHeight = 'md', marginBottom, color = 'low' }) =>
-    css`
+  ${({ theme }) => {
+    function mountFontModifiers(theme: HoustonTokens) {
+      const modifiers: any[] = [];
+      (['size', 'weight'] as const).forEach(fontProp =>
+        Object.entries(theme.font[fontProp]).forEach(([key, value]) =>
+          modifiers.push(css`
+            &.--${fontProp}-${key} {
+              font-${fontProp}: ${value};
+            }
+          `)
+        )
+      );
+      Object.entries(theme.line.height).forEach(([key, value]) =>
+        modifiers.push(css`
+          &.--line-height-${key} {
+            line-height: ${value};
+          }
+        `)
+      );
+      return modifiers;
+    }
+
+    return css`
       margin: 0;
-      font-size: ${theme.font.size[size]};
-      font-weight: ${theme.font.weight[weight]};
-      line-height: ${theme.line.height[lineHeight]};
-      margin-bottom: ${marginBottom ? theme.spacing.nano : null};
-      color: ${getColorFallback(theme, color).pure};
-    `}
+
+      ${mountFontModifiers(theme)}
+
+      &.--color-high {
+        color: ${theme.neutralColor.high.pure};
+      }
+
+      &.--color-low {
+        color: ${theme.neutralColor.low.pure};
+      }
+
+      &.--color-primary {
+        color: ${theme.brandColor.primary.pure};
+      }
+
+      &.--margin-bottom {
+        margin-bottom: ${theme.spacing.nano};
+      }
+    `;
+  }}
 `;


### PR DESCRIPTION
Olár, fiz duas coisas:

- Atualizei para utilizarmos os modifiers da maneira que decidimos;
- Os designers atualizaram o Heading, agora é mapeado os `font-weight` também;

Preview:
![image](https://user-images.githubusercontent.com/58918493/168684582-79c68bdb-722d-4e87-91c6-23c2c9fbadd2.png)
