### PR TITLE
Refactor button add tokens

### DIFF
--- a/src/pages/ui-components/Button/index.mdx
+++ b/src/pages/ui-components/Button/index.mdx
@@ -35,26 +35,22 @@ import Button from '@eduzz/houston-ui/Button';
   </Row>
 </Playground>
 
-### Cores
+### On Color
 
 <Playground>
-  <Row>
-    <Column>
-      <Button color='primary'>Primary</Button>
-    </Column>
-    <Column>
-      <Button color='positive'>Success</Button>
-    </Column>
-    <Column>
-      <Button color='negative'>Error</Button>
-    </Column>
-    <Column>
-      <Button color='informative'>Info</Button>
-    </Column>
-    <Column>
-      <Button color='warning'>Warning</Button>
-    </Column>
-  </Row>
+  <div className='ople'>
+    <Row>
+      <Column>
+        <Button onColor>Contained</Button>
+      </Column>
+      <Column>
+        <Button onColor>Outlined</Button>
+      </Column>
+      <Column>
+        <Button onColor>Text</Button>
+      </Column>
+    </Row>
+  </div>
 </Playground>
 
 ### Estados
@@ -66,11 +62,6 @@ import Button from '@eduzz/houston-ui/Button';
     </Column>
     <Column>
       <Button loading>loading</Button>
-    </Column>
-    <Column>
-      <Button loading loadingText='Carregando...'>
-        loading
-      </Button>
     </Column>
   </Row>
 </Playground>

--- a/src/pages/ui-components/Button/index.mdx
+++ b/src/pages/ui-components/Button/index.mdx
@@ -35,19 +35,23 @@ import Button from '@eduzz/houston-ui/Button';
   </Row>
 </Playground>
 
-### On Color
+### OnColor
 
 <Playground>
-  <div className='ople'>
+  <div style={{ padding: '30px', backgroundColor: '#0D2772' }}>
     <Row>
       <Column>
         <Button onColor>Contained</Button>
       </Column>
       <Column>
-        <Button onColor>Outlined</Button>
+        <Button variant='outlined' onColor>
+          Outlined
+        </Button>
       </Column>
       <Column>
-        <Button onColor>Text</Button>
+        <Button variant='text' onColor>
+          Text
+        </Button>
       </Column>
     </Row>
   </div>
@@ -74,21 +78,22 @@ import Button from '@eduzz/houston-ui/Button';
       <Button startIcon={<InsertEmoticonIcon />}>Start</Button>
     </Column>
     <Column>
-      <Button endIcon={<InsertEmoticonIcon />}>End</Button>
+      <Button variant='outlined' endIcon={<InsertEmoticonIcon />}>
+        End
+      </Button>
     </Column>
   </Row>
 </Playground>
 
-| prop        | tipo                                                           | obrigatório | padrão      |
-| ----------- | -------------------------------------------------------------- | ----------- | ----------- |
-| disabled    | `boolean`                                                      | `false`     | `false`     |
-| startIcon   | `React.ReactNode`                                              | `false`     | -           |
-| endIcon     | `React.ReactNode`                                              | `false`     | -           |
-| variant     | contained &#124; outlined &#124; text                          | `false`     | `contained` |
-| href        | `string`                                                       | `false`     | -           |
-| endIcon     | `React.ReactNode`                                              | `false`     | -           |
-| fullWidth   | `boolean`                                                      | `false`     | `false`     |
-| loading     | `boolean`                                                      | `false`     | `false`     |
-| loadingText | `string`                                                       | `false`     | -           |
-| onClick     | `function`                                                     | `false`     | -           |
-| color       | primary &#124; success &#124; error &#124; info &#124; warning | `false`     | `primary`   |
+| prop      | tipo                                  | obrigatório | padrão      |
+| --------- | ------------------------------------- | ----------- | ----------- |
+| disabled  | `boolean`                             | `false`     | `false`     |
+| startIcon | `React.ReactNode`                     | `false`     | -           |
+| endIcon   | `React.ReactNode`                     | `false`     | -           |
+| variant   | contained &#124; outlined &#124; text | `false`     | `contained` |
+| href      | `string`                              | `false`     | -           |
+| endIcon   | `React.ReactNode`                     | `false`     | -           |
+| fullWidth | `boolean`                             | `false`     | `false`     |
+| loading   | `boolean`                             | `false`     | `false`     |
+| onClick   | `function`                            | `false`     | -           |
+| onColor   | `boolean`                             | `false`     | `false`     |

--- a/src/pages/ui-components/Button/index.mdx
+++ b/src/pages/ui-components/Button/index.mdx
@@ -35,28 +35,6 @@ import Button from '@eduzz/houston-ui/Button';
   </Row>
 </Playground>
 
-### OnColor
-
-<Playground>
-  <div style={{ padding: '30px', backgroundColor: '#0D2772' }}>
-    <Row>
-      <Column>
-        <Button onColor>Contained</Button>
-      </Column>
-      <Column>
-        <Button variant='outlined' onColor>
-          Outlined
-        </Button>
-      </Column>
-      <Column>
-        <Button variant='text' onColor>
-          Text
-        </Button>
-      </Column>
-    </Row>
-  </div>
-</Playground>
-
 ### Estados
 
 <Playground>
@@ -96,4 +74,3 @@ import Button from '@eduzz/houston-ui/Button';
 | fullWidth | `boolean`                             | `false`     | `false`     |
 | loading   | `boolean`                             | `false`     | `false`     |
 | onClick   | `function`                            | `false`     | -           |
-| onColor   | `boolean`                             | `false`     | `false`     |

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -41,7 +41,7 @@ const Button: React.FC<IButtonProps> = props => {
       {...rest}
       disabled={disabled || loading}
     >
-      {!!startIcon && !loading && <span className='__startIcon'>{startIcon}</span>}
+      {!!startIcon && <span className={cx('__startIcon', { '--hidden': loading })}>{startIcon}</span>}
       {!loading && <span className='__text'>{children}</span>}
       {loading && (
         <>
@@ -49,22 +49,23 @@ const Button: React.FC<IButtonProps> = props => {
           <span className='__text --hidden'>{loadingText ?? children}</span>
         </>
       )}
-      {!!endIcon && <span className='__endIcon'>{endIcon}</span>}
+      {!!endIcon && <span className={cx('__endIcon', { '--hidden': loading })}>{endIcon}</span>}
     </button>
   );
 };
 
-const MIN_HEIGHT = 48;
+const HEIGHT = 48;
 const MIN_WIDTH = 140;
+const ICON_SIZE = 24;
 
 export default styled(Button, { label: 'houston-button' })(({ theme }) => {
   return css`
     border: none;
     cursor: pointer;
     text-transform: none;
-    min-height: ${theme.pxToRem(MIN_HEIGHT)}rem;
+    height: ${theme.pxToRem(HEIGHT)}rem;
     min-width: ${theme.pxToRem(MIN_WIDTH)}rem;
-    padding: ${theme.spacing.squish.xs};
+    padding: ${theme.spacing.squish.xxs};
     border-radius: ${theme.border.radius.xs};
     font-weight: ${theme.font.weight.semibold};
     font-family: ${theme.font.family.base};
@@ -114,15 +115,15 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
       }
     }
 
-    &.--fullWidth {
-      width: 100%;
-    }
-
     &.--disabled {
+      border: none;
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
       cursor: default;
-      border: none;
+    }
+
+    &.--fullWidth {
+      width: 100%;
     }
 
     & > .__loader {
@@ -136,17 +137,17 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
     }
 
     & > .__startIcon {
-      margin-right: ${theme.spacing.nano};
+      margin-right: ${theme.spacing.inline.nano};
     }
 
     & > .__endIcon {
-      margin-left: ${theme.spacing.nano};
+      margin-left: ${theme.spacing.inline.nano};
     }
 
     & > .__startIcon > svg,
     & > .__endIcon > svg {
       vertical-align: middle;
-      font-size: 17px;
+      font-size: ${theme.pxToRem(ICON_SIZE)}rem;
     }
   `;
 });

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -5,7 +5,6 @@ import styled, { css, cx, IStyledProp } from '@eduzz/houston-styles';
 import Spinner from '../Spinner';
 
 export type IButtonVariant = 'contained' | 'outlined' | 'text';
-export type IButtonColor = 'positive' | 'negative' | 'warning' | 'informative' | 'primary';
 
 export interface IButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -13,7 +12,6 @@ export interface IButtonProps
     IStyledProp {
   variant?: IButtonVariant;
   loading?: boolean;
-  onColor?: boolean;
   fullWidth?: boolean;
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
@@ -29,20 +27,13 @@ const Button: React.FC<IButtonProps> = props => {
     loading = false,
     className,
     fullWidth,
-    onColor = false,
     ...rest
   } = props;
 
   return (
     <button
       role='button'
-      className={cx(
-        className,
-        `--${variant ?? 'contained'}`,
-        { '--fullWidth': fullWidth },
-        { '--disabled': disabled },
-        { '--onColor': onColor }
-      )}
+      className={cx(className, `--${variant ?? 'contained'}`, { '--fullWidth': fullWidth }, { '--disabled': disabled })}
       {...rest}
       disabled={disabled || loading}
     >
@@ -50,7 +41,9 @@ const Button: React.FC<IButtonProps> = props => {
       {!loading && <span className='__text'>{children}</span>}
       {loading && (
         <>
-          <Spinner size={20} color='inherit' className='__loader' />
+          <span className='__loader'>
+            <Spinner size={20} color='inherit' />
+          </span>
           <span className='__text --hidden'>{children}</span>
         </>
       )}
@@ -94,23 +87,6 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
         background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
         transition: 0.3s background-color;
       }
-
-      &.--onColor {
-        background-color: ${theme.neutralColor.high.pure};
-        color: ${theme.neutralColor.low.pure};
-
-        &:hover:not(:disabled),
-        &:focus {
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[8])};
-          transition: 0.3s background-color;
-        }
-
-        &.--disabled {
-          border: none;
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
-        }
-      }
     }
 
     &.--outlined {
@@ -124,23 +100,6 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
         transition: 0.3s background-color;
       }
-
-      &.--onColor {
-        border-color: ${theme.neutralColor.high.pure};
-        color: ${theme.neutralColor.high.pure};
-
-        &:hover:not(:disabled),
-        &:focus {
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-          transition: 0.3s background-color;
-        }
-
-        &.--disabled {
-          border: none;
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
-        }
-      }
     }
 
     &.--text {
@@ -151,22 +110,6 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
       &:focus {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
         transition: 0.3s background-color;
-      }
-
-      &.--onColor {
-        border-color: ${theme.neutralColor.high.pure};
-        color: ${theme.neutralColor.high.pure};
-
-        &:hover:not(:disabled),
-        &:focus {
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-          transition: 0.3s background-color;
-        }
-
-        &.--disabled {
-          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
-        }
       }
     }
 

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -15,6 +15,7 @@ export interface IButtonProps
   loading?: boolean;
   loadingText?: string;
   color?: IButtonColor;
+  onColor?: boolean;
   fullWidth?: boolean;
   startIcon?: React.ReactNode;
   endIcon?: React.ReactNode;
@@ -31,13 +32,20 @@ const Button: React.FC<IButtonProps> = props => {
     loadingText,
     className,
     fullWidth,
+    onColor = false,
     ...rest
   } = props;
 
   return (
     <button
       role='button'
-      className={cx(className, `--${variant ?? 'contained'}`, { '--fullWidth': fullWidth }, { '--disabled': disabled })}
+      className={cx(
+        className,
+        `--${variant ?? 'contained'}`,
+        { '--fullWidth': fullWidth },
+        { '--disabled': disabled },
+        { '--onColor': onColor }
+      )}
       {...rest}
       disabled={disabled || loading}
     >
@@ -148,6 +156,24 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
     & > .__endIcon > svg {
       vertical-align: middle;
       font-size: ${theme.pxToRem(ICON_SIZE)}rem;
+    }
+
+    &.--onColor {
+      background-color: ${theme.neutralColor.high.pure};
+      color: ${theme.neutralColor.low.pure};
+
+      &:hover:not(:disabled),
+      &:focus {
+        background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[8])};
+        transition: 0.3s background-color;
+      }
+
+      &.--disabled {
+        border: none;
+        background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+        color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
+        cursor: default;
+      }
     }
   `;
 });

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -13,8 +13,6 @@ export interface IButtonProps
     IStyledProp {
   variant?: IButtonVariant;
   loading?: boolean;
-  loadingText?: string;
-  color?: IButtonColor;
   onColor?: boolean;
   fullWidth?: boolean;
   startIcon?: React.ReactNode;
@@ -29,7 +27,6 @@ const Button: React.FC<IButtonProps> = props => {
     endIcon,
     variant,
     loading = false,
-    loadingText,
     className,
     fullWidth,
     onColor = false,
@@ -54,7 +51,7 @@ const Button: React.FC<IButtonProps> = props => {
       {loading && (
         <>
           <Spinner size={20} color='inherit' className='__loader' />
-          <span className='__text --hidden'>{loadingText ?? children}</span>
+          <span className='__text --hidden'>{children}</span>
         </>
       )}
       {!!endIcon && <span className={cx('__endIcon', { '--hidden': loading })}>{endIcon}</span>}
@@ -97,10 +94,27 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
         background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
         transition: 0.3s background-color;
       }
+
+      &.--onColor {
+        background-color: ${theme.neutralColor.high.pure};
+        color: ${theme.neutralColor.low.pure};
+
+        &:hover:not(:disabled),
+        &:focus {
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[8])};
+          transition: 0.3s background-color;
+        }
+
+        &.--disabled {
+          border: none;
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
+        }
+      }
     }
 
     &.--outlined {
-      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+      background-color: transparent;
       border: ${theme.border.width.xs} solid;
       border-color: ${theme.neutralColor.low.pure};
       color: ${theme.neutralColor.low.pure};
@@ -109,6 +123,23 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
       &:focus {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
         transition: 0.3s background-color;
+      }
+
+      &.--onColor {
+        border-color: ${theme.neutralColor.high.pure};
+        color: ${theme.neutralColor.high.pure};
+
+        &:hover:not(:disabled),
+        &:focus {
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+          transition: 0.3s background-color;
+        }
+
+        &.--disabled {
+          border: none;
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
+        }
       }
     }
 
@@ -120,6 +151,22 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
       &:focus {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
         transition: 0.3s background-color;
+      }
+
+      &.--onColor {
+        border-color: ${theme.neutralColor.high.pure};
+        color: ${theme.neutralColor.high.pure};
+
+        &:hover:not(:disabled),
+        &:focus {
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+          transition: 0.3s background-color;
+        }
+
+        &.--disabled {
+          background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
+          color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
+        }
       }
     }
 
@@ -156,24 +203,6 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
     & > .__endIcon > svg {
       vertical-align: middle;
       font-size: ${theme.pxToRem(ICON_SIZE)}rem;
-    }
-
-    &.--onColor {
-      background-color: ${theme.neutralColor.high.pure};
-      color: ${theme.neutralColor.low.pure};
-
-      &:hover:not(:disabled),
-      &:focus {
-        background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[8])};
-        transition: 0.3s background-color;
-      }
-
-      &.--disabled {
-        border: none;
-        background-color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[4])};
-        color: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
-        cursor: default;
-      }
     }
   `;
 });

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -45,8 +45,8 @@ const Button: React.FC<IButtonProps> = props => {
       {!loading && <span className='__text'>{children}</span>}
       {loading && (
         <>
-          <Spinner size={15} color='inherit' className='__loader' />
-          <span className='__text'>{loadingText ?? children}</span>
+          <Spinner size={20} color='inherit' className='__loader' />
+          <span className='__text --hidden'>{loadingText ?? children}</span>
         </>
       )}
       {!!endIcon && <span className='__endIcon'>{endIcon}</span>}
@@ -70,12 +70,49 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
     font-family: ${theme.font.family.base};
     line-height: ${theme.line.height.default};
     font-size: ${theme.font.size.xs};
-    background-color: ${theme.brandColor.primary.pure};
-    color: ${theme.neutralColor.high.pure};
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
+
+    :focus {
+      outline: solid ${theme.border.width.sm} ${theme.feedbackColor.informative.pure};
+    }
+
+    &.--contained {
+      background-color: ${theme.brandColor.primary.pure};
+      color: ${theme.neutralColor.high.pure};
+
+      &:hover:not(:disabled),
+      &:focus {
+        background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
+        transition: 0.3s background-color;
+      }
+    }
+
+    &.--outlined {
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+      border: ${theme.border.width.xs} solid;
+      border-color: ${theme.neutralColor.low.pure};
+      color: ${theme.neutralColor.low.pure};
+
+      &:hover:not(:disabled),
+      &:focus {
+        background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
+        transition: 0.3s background-color;
+      }
+    }
+
+    &.--text {
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+      color: ${theme.neutralColor.low.pure};
+
+      &:hover:not(:disabled),
+      &:focus {
+        background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
+        transition: 0.3s background-color;
+      }
+    }
 
     &.--fullWidth {
       width: 100%;
@@ -85,37 +122,17 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
       cursor: default;
-    }
-
-    &.--outlined {
-      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
-      border: 1px solid;
-      border-color: ${theme.neutralColor.low.pure};
-      color: ${theme.neutralColor.low.pure};
-    }
-
-    &.--text {
-      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
       border: none;
-      color: ${theme.neutralColor.low.pure};
-    }
-
-    &.--contained {
-      &:hover:not(:disabled) {
-        background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
-        transition: 0.3s background-color;
-      }
-      &:focus {
-        background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
-      }
-    }
-
-    :focus {
-      outline: solid ${theme.border.width.sm} ${theme.feedbackColor.informative.pure};
     }
 
     & > .__loader {
-      margin-right: ${theme.spacing.nano};
+      position: absolute;
+      left: 50%;
+      transform: translate(-50%, 0);
+    }
+
+    & > .--hidden {
+      visibility: hidden;
     }
 
     & > .__startIcon {

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import styled, { css, cx, IStyledProp } from '@eduzz/houston-styles';
 
 import Spinner from '../Spinner';
-import getColorFallback from '../utils/getColorFallback';
 
 export type IButtonVariant = 'contained' | 'outlined' | 'text';
 export type IButtonColor = 'positive' | 'negative' | 'warning' | 'informative' | 'primary';
@@ -38,7 +37,7 @@ const Button: React.FC<IButtonProps> = props => {
   return (
     <button
       role='button'
-      className={cx(className, `--${variant ?? 'contained'}`, { '--fullWidth': fullWidth })}
+      className={cx(className, `--${variant ?? 'contained'}`, { '--fullWidth': fullWidth }, { '--disabled': disabled })}
       {...rest}
       disabled={disabled || loading}
     >
@@ -55,22 +54,25 @@ const Button: React.FC<IButtonProps> = props => {
   );
 };
 
-export default styled(Button, { label: 'houston-button' })(({ theme, color: colorProp }) => {
-  const color = getColorFallback(theme, colorProp);
+const MIN_HEIGHT = 48;
+const MIN_WIDTH = 140;
 
+export default styled(Button, { label: 'houston-button' })(({ theme }) => {
   return css`
     border: none;
     cursor: pointer;
     text-transform: none;
-    padding: 10px 16px;
-    height: 40px;
+    min-height: ${theme.pxToRem(MIN_HEIGHT)}rem;
+    min-width: ${theme.pxToRem(MIN_WIDTH)}rem;
+    padding: ${theme.spacing.squish.xs};
     border-radius: ${theme.border.radius.xs};
-    font-weight: ${theme.font.weight.bold};
+    font-weight: ${theme.font.weight.semibold};
     font-family: ${theme.font.family.base};
     line-height: ${theme.line.height.default};
-    font-size: ${theme.font.size.xxs};
+    font-size: ${theme.font.size.xs};
+    background-color: ${theme.brandColor.primary.pure};
+    color: ${theme.neutralColor.high.pure};
     position: relative;
-    transition: 0.3s;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -79,66 +81,37 @@ export default styled(Button, { label: 'houston-button' })(({ theme, color: colo
       width: 100%;
     }
 
-    &.--contained {
-      background-color: ${color.pure};
-      color: white;
-
-      &:hover:not(:disabled) {
-        background-color: ${color.light};
-      }
-
-      &:active:not(:disabled) {
-        background-color: ${color.dark};
-      }
-
-      &:disabled {
-        background-color: ${theme.neutralColor.high.medium};
-      }
+    &.--disabled {
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
+      color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
+      cursor: default;
     }
 
     &.--outlined {
-      background-color: transparent;
-      color: ${color.pure};
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
       border: 1px solid;
-      border-color: ${color.light};
-
-      &:hover:not(:disabled),
-      &:active:not(:disabled) {
-        border-color: ${color.dark};
-        color: ${color.dark};
-      }
+      border-color: ${theme.neutralColor.low.pure};
+      color: ${theme.neutralColor.low.pure};
     }
 
     &.--text {
-      background-color: transparent;
-      color: ${color.pure};
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+      border: none;
+      color: ${theme.neutralColor.low.pure};
+    }
 
-      &:hover:not(:disabled),
-      &:active:not(:disabled) {
-        background-color: ${theme.neutralColor.high.light};
+    &.--contained {
+      &:hover:not(:disabled) {
+        background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
+        transition: 0.3s background-color;
+      }
+      &:focus {
+        background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
       }
     }
 
-    &:disabled {
-      cursor: default;
-      color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
-      border-color: ${theme.neutralColor.high.medium};
-    }
-
-    &:before {
-      content: ' ';
-      position: absolute;
-      left: -4px;
-      right: -4px;
-      top: -4px;
-      bottom: -4px;
-      border: 2px solid transparent;
-      transition: 0.3s;
-      border-radius: ${theme.border.radius.sm};
-    }
-
-    &:focus:not(:active):not(:hover):before {
-      border-color: ${theme.neutralColor.high.medium};
+    :focus {
+      outline: solid ${theme.border.width.sm} ${theme.feedbackColor.informative.pure};
     }
 
     & > .__loader {


### PR DESCRIPTION
Button remodelado e tokenizado de acordo com novo design :

https://www.figma.com/file/WJWEph4jRV7uuVe4e9Pj13/Houston-desktop-components-handoff?node-id=1028%3A19253

Adicionei uma prop onColor que seria o botão no modo "darkmode" 

Atualizei as docs

**Breaking changes :** 
   _prop color removida
   prop loadingText removida_
   
   