### PR TITLE
feat(hooks): melhora no tratamento de promises

### DIFF
--- a/src/pages/hooks/config.tsx
+++ b/src/pages/hooks/config.tsx
@@ -11,7 +11,8 @@ export interface IHoustonHooksConfig {
 }
 
 let _config: IHoustonHooksConfig = {
-  onUnhandledError() {
+  onUnhandledError(err) {
+    console.error(err);
     /*do nothing */
   },
   pagination: { pageStart: 1, perPage: 25 }

--- a/src/pages/hooks/usePromise/index.mdx
+++ b/src/pages/hooks/usePromise/index.mdx
@@ -49,6 +49,29 @@ return (
   }}
 </Playground>
 
+## Setando um estado extra
+
+Quando necessário setar um estado extra sempre verique a função **isSubscribe**, ele retornará se o componente ainda está
+montado e assim evitará **Memory Leak**.
+
+```tsx
+const [other, setOther] = useState();
+const [value, error, loading] = usePromise(async isSubscribe => {
+  const result = await userService.get();
+  if (isSubscribe()) {
+    setOther(result.otherValue);
+  }
+  return result;
+}, []);
+
+return (
+  <div>
+    {loading ? 'Carregando' : ''}
+    {value}
+  </div>
+);
+```
+
 ## Cuidados
 
 - **Erros** ocorridos serão automaticamentes logados e as o **onUnhandledError** no **setHoustonHooksConfig**

--- a/src/pages/hooks/usePromise/index.tsx
+++ b/src/pages/hooks/usePromise/index.tsx
@@ -9,7 +9,7 @@ import { getConfig } from '../config';
  * @returns [value, error, loading]
  */
 export default function usePromise<T>(
-  promiseGenerator: () => Promise<T>,
+  promiseGenerator: (isSubscribed: () => boolean) => Promise<T>,
   deps: React.DependencyList
 ): [T, any, boolean] {
   const [loading, setLoading] = React.useState<boolean>(true);
@@ -20,7 +20,7 @@ export default function usePromise<T>(
     let isSubscribed = true;
     setLoading(true);
 
-    promiseGenerator()
+    promiseGenerator(() => isSubscribed)
       .then(result => {
         if (!isSubscribed) return;
         setResult(() => result);

--- a/src/pages/hooks/usePromiseCallback/index.mdx
+++ b/src/pages/hooks/usePromiseCallback/index.mdx
@@ -2,7 +2,7 @@
 name: usePromiseCallback
 ---
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 
 import { Playground } from 'dokz';
 
@@ -19,29 +19,53 @@ unsubscribe, diminuindo assim o risco de Memory Leak. **Como useEffect que retor
 ## Como usar
 
 ```tsx
-const [callback, value, error, loading] = usePromiseCallback(() => userService.get(), []);
+const [loading, setLoading] = useState();
+const callback = usePromiseCallback(async isSubscribe => {
+  setLoading(true);
+  await userService.get();
+  // Se for setar um estado sempre verifique o isSubscribe, para evitar Memory Leak, e subsequentes chamadas
+  // farão que chamadas anteriores não alterem estados.
+  if (isSubscribe()) setLoading(false);
+}, []);
 
 return (
   <div>
     {loading ? 'Carregando' : ''}
-    {value}
     <button onClick={callback}>iniciar</button>
   </div>
 );
 ```
 
+Veja o exemplo abaixo:
+
 <Playground>
   {() => {
+    const callCounter = useRef(0);
     const [reset, setReset] = useState();
-    const [callback, value, error, loading] = usePromiseCallback(
-      () => new Promise(resolve => setTimeout(() => resolve('olá'), 2000)),
+    const [loading, setLoading] = useState(false);
+    const [completed, setCompleted] = useState([]);
+    const [ignored, setIgnored] = useState([]);
+    const callback = usePromiseCallback(
+      isSubscribe => {
+        const currentCall = ++callCounter.current;
+        setLoading(true);
+        return new Promise(resolve => setTimeout(() => resolve('olá'), 2000)).then(() => {
+          if (isSubscribe()) {
+            setLoading(false);
+            setCompleted(completed => [...completed, currentCall]);
+          } else {
+            setIgnored(ignored => [...ignored, currentCall]);
+          }
+        });
+      },
       [reset]
     );
     return (
       <div>
-        <Typography>Value: {value}</Typography>
-        <Typography marginBottom>Loading: {loading.toString()}</Typography>
-        <Button onClick={callback}>Iniciar</Button>
+        <p>Loading: {loading.toString()}</p>
+        <p>cliques completos: {JSON.stringify(completed)}</p>
+        <p>cliques ignorados: {JSON.stringify(ignored)}</p>
+        <Button onClick={callback}>Iniciar (Tente clicar mais de uma vez)</Button>
       </div>
     );
   }}
@@ -51,7 +75,6 @@ return (
 
 - **Erros** ocorridos serão automaticamentes logados e as o **onUnhandledError** no **setHoustonHooksConfig**
   for setado.
-- O valor inicial será **undefined**, lembre-se de tratar isso quando estiver usando.
 
 ## Parâmetros e Retorno
 

--- a/src/pages/hooks/usePromiseEffect/index.mdx
+++ b/src/pages/hooks/usePromiseEffect/index.mdx
@@ -13,8 +13,8 @@ import usePromiseEffect from '.';
 
 # usePromiseEffect
 
-Dá Subscribe e retorna o resultado de uma promise e quando o componente desmonta (unmount) também dá unsubscribe,
-diminuindo assim o risco de Memory Leak. **Como useEffect que retorna o valor da Promise**
+Dá Subscribe em uma promise e quando o componente desmonta (unmount) também dá unsubscribe,
+diminuindo assim o risco de Memory Leak. **Como um useEffect** ele não gerá estado diminuindo o número de renders.
 
 ## Como usar
 
@@ -37,11 +37,14 @@ return (
 
 <Playground>
   {() => {
-    usePromiseEffect(async isSubscribed => {
-      await new Promise(resolve => setTimeout(() => resolve('olá'), 2000));
-      console.log({ isSubscribed: isSubscribed() });
+    const [loading, setLoading] = useState(false);
+    usePromiseEffect(isSubscribed => {
+      setLoading(true);
+      return new Promise(resolve => setTimeout(() => resolve('olá'), 2000)).then(() => {
+        if (isSubscribed()) setLoading(false);
+      });
     }, []);
-    return <div />;
+    return <div>Loading: {loading.toString()}</div>;
   }}
 </Playground>
 

--- a/src/pages/hooks/usePromiseEffect/index.tsx
+++ b/src/pages/hooks/usePromiseEffect/index.tsx
@@ -13,10 +13,11 @@ export default function usePromiseEffect<T>(
   deps: React.DependencyList
 ): void {
   React.useEffect(() => {
-    let isSubscribed = false;
+    let isSubscribed = true;
 
     promiseGenerator(() => isSubscribed).catch(err => {
       getConfig().onUnhandledError(err, 'hooks');
+      throw err;
     });
 
     return () => {

--- a/src/pages/hooks/usePromiseRefresh/index.tsx
+++ b/src/pages/hooks/usePromiseRefresh/index.tsx
@@ -10,7 +10,7 @@ import usePromise from '../usePromise';
  * @returns [value, error, loading, refresh]
  */
 export default function usePromiseRefresh<T>(
-  promiseGenerator: () => Promise<T>,
+  promiseGenerator: (isSubscribed: () => boolean) => Promise<T>,
   deps: React.DependencyList
 ): [T, any, boolean, () => void] {
   const [refresh, setRefresh] = React.useState<number>();

--- a/src/pages/ui-components/ThemeProvider/index.tsx
+++ b/src/pages/ui-components/ThemeProvider/index.tsx
@@ -66,7 +66,7 @@ function ThemeProvider({
   return (
     <StyledEngineProvider injectFirst>
       <MUIThemeProvider theme={muiTheme}>
-        <LocalizationProvider locale={ptBR} dateAdapter={AdapterDateFns}>
+        <LocalizationProvider adapterLocale={ptBR} dateAdapter={AdapterDateFns}>
           <PopoverRoot>
             {!disableToast && <ToastContainer />}
             {!disableCssBaseline && <CssBaseline />}


### PR DESCRIPTION
* Todos os looks de promise agora recebem uma função chamada **isSubscribed**, ela diz que o componente está montando ainda ou se aquela chamada ainda é válida (pensando em concorrência).

## Break Change

usePromiseCallback foi simplificado para ficar mais parecido com o useCallback, ou seja, não gera mais estado.