### PR TITLE
Refactor/tool tip

### DIFF
--- a/src/pages/ui-components/Popover/index.tsx
+++ b/src/pages/ui-components/Popover/index.tsx
@@ -78,8 +78,6 @@ export default styled(Popover, { label: 'houston-popover' })(
     & > .__container {
       width: 100%;
       max-height: 50vh;
-      overflow-y: auto;
-      overflow-x: hidden;
       background-color: white;
       box-shadow: ${theme.shadow.level[1]};
       border-radius: ${theme.border.radius.xs};

--- a/src/pages/ui-components/Popover/index.tsx
+++ b/src/pages/ui-components/Popover/index.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Placement } from '@popperjs/core';
 import { useContextSelector } from 'use-context-selector';
 
-import { IStyledProp } from '@eduzz/houston-styles';
+import { IStyledProp, cx } from '@eduzz/houston-styles';
 
 import PopoverContext from './context';
 
@@ -14,6 +14,8 @@ export interface IPopoverProps extends IStyledProp {
   children?: React.ReactNode;
   fullWidth?: boolean;
   placement?: Placement;
+  id?: string;
+  variant?: 'tooltip';
 }
 
 export interface IPopoverRef {
@@ -22,7 +24,7 @@ export interface IPopoverRef {
 }
 
 const Popover = React.forwardRef<IPopoverRef, IPopoverProps>(
-  ({ targetRef, children, className, fullWidth, placement }, ref) => {
+  ({ targetRef, children, className, fullWidth, placement, id, variant }, ref) => {
     const setState = useContextSelector(PopoverContext, context => context.setState);
     const contentRef = React.useRef<HTMLDivElement>();
     const closeRef = React.useRef<() => void>();
@@ -48,8 +50,8 @@ const Popover = React.forwardRef<IPopoverRef, IPopoverProps>(
     );
 
     return (
-      <div ref={contentRef} className={className}>
-        <div className='__container'>{children}</div>
+      <div id={id} ref={contentRef} className={className}>
+        <div className={cx('__container', { [`--${variant}`]: !!variant })}>{children}</div>
       </div>
     );
   }
@@ -78,6 +80,8 @@ export default styled(Popover, { label: 'houston-popover' })(
     & > .__container {
       width: 100%;
       max-height: 50vh;
+      overflow-y: auto;
+      overflow-x: hidden;
       background-color: white;
       box-shadow: ${theme.shadow.level[1]};
       border-radius: ${theme.border.radius.xs};
@@ -86,6 +90,11 @@ export default styled(Popover, { label: 'houston-popover' })(
       animation-duration: 0.2s;
       animation-name: ${hideAnimation};
       animation-fill-mode: forwards;
+
+      &.--tooltip {
+        overflow-y: unset;
+        overflow-x: unset;
+      }
     }
 
     &.--opened {

--- a/src/pages/ui-components/Popover/index.tsx
+++ b/src/pages/ui-components/Popover/index.tsx
@@ -50,7 +50,7 @@ const Popover = React.forwardRef<IPopoverRef, IPopoverProps>(
     );
 
     return (
-      <div id={id} ref={contentRef} className={className}>
+      <div id={id} ref={contentRef} className={cx(className, 'popover')}>
         <div className={cx('__container', { [`--${variant}`]: !!variant })}>{children}</div>
       </div>
     );

--- a/src/pages/ui-components/Tooltip/TooltipBody.tsx
+++ b/src/pages/ui-components/Tooltip/TooltipBody.tsx
@@ -7,10 +7,31 @@ export interface ITooltipBody extends IStyledProp {
   title: React.ReactNode;
 }
 
+const styleContent = {
+  __html: `
+      .popover[data-popper-placement^='top'] #houston-tooltip-arrow {
+        bottom: -4px;
+      }
+
+     .popover[data-popper-placement^='bottom'] #houston-tooltip-arrow {
+        top: -4px;
+      }
+
+      .popover[data-popper-placement^='left'] #houston-tooltip-arrow {
+        right: -4px;
+      }
+
+      .popover[data-popper-placement^='right'] #houston-tooltip-arrow {
+        left: -4px;
+      }
+    `
+};
+
 const TooltipBody = ({ className, title }: ITooltipBody) => {
   return (
     <div role='tooltip' className={className}>
       <div id='houston-tooltip-arrow' data-popper-arrow />
+      <style dangerouslySetInnerHTML={styleContent} />
       <Caption color='neutralColor.high.pure'>{title}</Caption>
     </div>
   );
@@ -40,38 +61,6 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
       visibility: visible;
       content: '';
       transform: rotate(45deg);
-    }
-
-    &.--placement-top,
-    &.--placement-top-start,
-    &.--placement-top-end {
-      > #houston-tooltip-arrow {
-        bottom: -4px;
-      }
-    }
-
-    &.--placement-bottom,
-    &.--placement-bottom-start,
-    &.--placement-bottom-end {
-      > #houston-tooltip-arrow {
-        top: -4px;
-      }
-    }
-
-    &.--placement-left,
-    &.--placement-left-start,
-    &.--placement-left-end {
-      > #houston-tooltip-arrow {
-        right: -4px;
-      }
-    }
-
-    &.--placement-right,
-    &.--placement-right-start,
-    &.--placement-right-end {
-      > #houston-tooltip-arrow {
-        left: -4px;
-      }
     }
   `}
 `);

--- a/src/pages/ui-components/Tooltip/TooltipBody.tsx
+++ b/src/pages/ui-components/Tooltip/TooltipBody.tsx
@@ -3,11 +3,15 @@ import * as React from 'react';
 import styled, { css, IStyledProp } from '@eduzz/houston-styles';
 import Caption from '@eduzz/houston-ui/Typography/Caption';
 
-const TooltipBody = ({ className }: IStyledProp) => {
+export interface ITooltipBody extends IStyledProp {
+  title: React.ReactNode;
+}
+
+const TooltipBody = ({ className, title }: ITooltipBody) => {
   return (
-    <div className={className}>
+    <div role='tooltip' className={className}>
       <div id='arrow' data-popper-arrow></div>
-      <Caption color='neutralColor.high.pure'>Eu sou o tooltip </Caption>
+      <Caption color='neutralColor.high.pure'>{title}</Caption>
     </div>
   );
 };
@@ -15,7 +19,6 @@ const TooltipBody = ({ className }: IStyledProp) => {
 export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
   ${({ theme }) => css`
     padding: ${theme.spacing.inset.xxs};
-    border: ${theme.border.width.xs} solid;
     border-radius: ${theme.border.radius.xs};
     min-width: ${theme.spacing.xl};
     background-color: ${theme.neutralColor.low.pure};

--- a/src/pages/ui-components/Tooltip/TooltipBody.tsx
+++ b/src/pages/ui-components/Tooltip/TooltipBody.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import styled, { css, IStyledProp } from '@eduzz/houston-styles';
+import Caption from '@eduzz/houston-ui/Typography/Caption';
+
+const TooltipBody = ({ className }: IStyledProp) => {
+  return (
+    <div className={className}>
+      <div id='arrow' data-popper-arrow></div>
+      <Caption color='neutralColor.high.pure'>Eu sou o tooltip </Caption>
+    </div>
+  );
+};
+
+export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
+  ${({ theme }) => css`
+    padding: ${theme.spacing.inset.xxs};
+    border: ${theme.border.width.xs} solid;
+    border-radius: ${theme.border.radius.xs};
+    min-width: ${theme.spacing.xl};
+    background-color: ${theme.neutralColor.low.pure};
+
+    #arrow,
+    #arrow::before {
+      position: absolute;
+      width: 8px;
+      height: 8px;
+      background: inherit;
+      color: inherit;
+    }
+
+    #arrow {
+      visibility: hidden;
+    }
+
+    #arrow::before {
+      visibility: visible;
+      content: '';
+      transform: rotate(45deg);
+    }
+
+    &.--placement-top,
+    &.--placement-top-start,
+    &.--placement-top-end {
+      > #arrow {
+        bottom: -4px;
+      }
+    }
+
+    &.--placement-bottom,
+    &.--placement-bottom-start,
+    &.--placement-bottom-end {
+      > #arrow {
+        top: -4px;
+      }
+    }
+
+    &.--placement-left,
+    &.--placement-left-start,
+    &.--placement-left-end {
+      > #arrow {
+        right: -4px;
+      }
+    }
+
+    &.--placement-right,
+    &.--placement-right-start,
+    &.--placement-right-end {
+      > #arrow {
+        left: -4px;
+      }
+    }
+  `}
+`);

--- a/src/pages/ui-components/Tooltip/TooltipBody.tsx
+++ b/src/pages/ui-components/Tooltip/TooltipBody.tsx
@@ -10,7 +10,7 @@ export interface ITooltipBody extends IStyledProp {
 const TooltipBody = ({ className, title }: ITooltipBody) => {
   return (
     <div role='tooltip' className={className}>
-      <div id='arrow' data-popper-arrow></div>
+      <div id='houston-tooltip-arrow' data-popper-arrow />
       <Caption color='neutralColor.high.pure'>{title}</Caption>
     </div>
   );
@@ -23,8 +23,8 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
     min-width: ${theme.spacing.xl};
     background-color: ${theme.neutralColor.low.pure};
 
-    #arrow,
-    #arrow::before {
+    #houston-tooltip-arrow,
+    #houston-tooltip-arrow::before {
       position: absolute;
       width: 8px;
       height: 8px;
@@ -32,11 +32,11 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
       color: inherit;
     }
 
-    #arrow {
+    #houston-tooltip-arrow {
       visibility: hidden;
     }
 
-    #arrow::before {
+    #houston-tooltip-arrow::before {
       visibility: visible;
       content: '';
       transform: rotate(45deg);
@@ -45,7 +45,7 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
     &.--placement-top,
     &.--placement-top-start,
     &.--placement-top-end {
-      > #arrow {
+      > #houston-tooltip-arrow {
         bottom: -4px;
       }
     }
@@ -53,7 +53,7 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
     &.--placement-bottom,
     &.--placement-bottom-start,
     &.--placement-bottom-end {
-      > #arrow {
+      > #houston-tooltip-arrow {
         top: -4px;
       }
     }
@@ -61,7 +61,7 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
     &.--placement-left,
     &.--placement-left-start,
     &.--placement-left-end {
-      > #arrow {
+      > #houston-tooltip-arrow {
         right: -4px;
       }
     }
@@ -69,7 +69,7 @@ export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
     &.--placement-right,
     &.--placement-right-start,
     &.--placement-right-end {
-      > #arrow {
+      > #houston-tooltip-arrow {
         left: -4px;
       }
     }

--- a/src/pages/ui-components/Tooltip/index.mdx
+++ b/src/pages/ui-components/Tooltip/index.mdx
@@ -63,11 +63,10 @@ import Tooltip from '@eduzz/houston-ui/Tooltip';
   </Row>
 </Playground>
 
-| prop      | tipo                | obrigatório | padrão  | descrição                                |
-| --------- | ------------------- | ----------- | ------- | ---------------------------------------- |
-| title     | `string`            | `true`      | -       | -                                        |
-| disabled  | `boolean`           | `false`     | `false` | -                                        |
-| placement | `ITooltipPlacement` | `false`     | `top`   | -                                        |
-| open      | `boolean`           | `false`     | `false` | Se verdadeiro, sempre exibirá o `title`. |
-| onOpen    | `function`          | `false`     | -       | -                                        |
-| onClose   | `function`          | `false`     | -       | -                                        |
+| prop      | tipo                | obrigatório | padrão  | descrição |
+| --------- | ------------------- | ----------- | ------- | --------- |
+| title     | `string`            | `true`      | -       | -         |
+| disabled  | `boolean`           | `false`     | `false` | -         |
+| placement | `ITooltipPlacement` | `false`     | `top`   | -         |
+| onOpen    | `function`          | `false`     | -       | -         |
+| onClose   | `function`          | `false`     | -       | -         |

--- a/src/pages/ui-components/Tooltip/index.tsx
+++ b/src/pages/ui-components/Tooltip/index.tsx
@@ -21,7 +21,7 @@ type ITooltipPlacement =
   | 'top';
 
 export interface ITooltipProps extends IStyledProp {
-  title?: React.ReactNode;
+  title: React.ReactNode;
   placement?: ITooltipPlacement;
   disabled?: boolean;
   children: React.ReactNode;
@@ -30,10 +30,10 @@ export interface ITooltipProps extends IStyledProp {
   onClose?(): void;
 }
 
-const Tooltip = ({ children, placement = 'top', id: idProp, disabled, onOpen, onClose }: ITooltipProps) => {
+const Tooltip = ({ children, title, placement = 'top', id: idProp, disabled, onOpen, onClose }: ITooltipProps) => {
   const { openPopover, closePopover, popoverTargetProps, popoverProps } = usePopover();
 
-  const [id] = React.useState(idProp ?? `${Math.floor(Math.random() * 100)}`);
+  const [id] = React.useState(idProp ?? `${Math.floor(Math.random() * 1000)}`);
 
   const onOpenPopover = React.useCallback(() => {
     onOpen && onOpen();
@@ -50,7 +50,7 @@ const Tooltip = ({ children, placement = 'top', id: idProp, disabled, onOpen, on
       <>
         {!disabled && (
           <Popover {...popoverProps} placement={placement}>
-            <TooltipBody className={`--placement-${placement}`} />
+            <TooltipBody className={`--placement-${placement}`} title={title} />
           </Popover>
         )}
         <span id={id} tabIndex={0} {...popoverTargetProps} onMouseEnter={onOpenPopover} onMouseLeave={onClosePopover}>

--- a/src/pages/ui-components/Tooltip/index.tsx
+++ b/src/pages/ui-components/Tooltip/index.tsx
@@ -1,5 +1,7 @@
-/* eslint-disable react/no-children-prop */
 import * as React from 'react';
+
+import styled, { css, IStyledProp } from '@eduzz/houston-styles';
+import Caption from '@eduzz/houston-ui/Typography/Caption';
 
 import Popover from '../Popover';
 import usePopover from '../Popover/usePopover';
@@ -26,17 +28,84 @@ export interface ITooltipProps {
   className?: string;
 }
 
-const Tooltip = ({ children }: ITooltipProps) => {
+const TooltipBody = ({ className }: IStyledProp) => {
+  return (
+    <div className={className}>
+      <div id='arrow' data-popper-arrow></div>
+      <Caption color='neutralColor.high.pure'>Eu sou o tooltip </Caption>
+    </div>
+  );
+};
+
+const StyledTooltipBody = React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
+  ${({ theme }) => css`
+    padding: ${theme.spacing.inset.xxs};
+    border: ${theme.border.width.xs} solid;
+    border-radius: ${theme.border.radius.xs};
+    min-width: ${theme.spacing.xl};
+    background-color: ${theme.neutralColor.low.pure};
+
+    #arrow,
+    #arrow::before {
+      position: absolute;
+      width: 8px;
+      height: 8px;
+      background: inherit;
+      color: inherit;
+    }
+
+    #arrow {
+      visibility: hidden;
+    }
+
+    #arrow::before {
+      visibility: visible;
+      content: '';
+      transform: rotate(45deg);
+    }
+
+    &.--placement-top {
+      > #arrow {
+        bottom: -4px;
+      }
+    }
+
+    &.--placement-bottom {
+      > #arrow {
+        top: -4px;
+      }
+    }
+
+    &.--placement-left {
+      > #arrow {
+        right: -4px;
+      }
+    }
+
+    &.--placement-right {
+      > #arrow {
+        left: -4px;
+      }
+    }
+  `}
+`);
+
+const Tooltip = ({ children, placement }: ITooltipProps) => {
   const { openPopover, closePopover, popoverTargetProps, popoverProps } = usePopover();
 
   return (
     <>
-      <Popover {...popoverProps} placement='bottom-start'>
-        <div>Eu sou o tooltip</div>
+      <Popover {...popoverProps} placement={placement}>
+        <StyledTooltipBody className={`--placement-${placement}`} />
       </Popover>
-      <span {...popoverTargetProps} onMouseEnter={openPopover} onMouseLeave={closePopover}>
+      <div
+        {...popoverTargetProps}
+        tabIndex={0}
+        onMouseEnter={openPopover}
+        /* onMouseLeave={closePopover}*/
+      >
         {children}
-      </span>
+      </div>
     </>
   );
 };

--- a/src/pages/ui-components/Tooltip/index.tsx
+++ b/src/pages/ui-components/Tooltip/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-children-prop */
 import * as React from 'react';
 
-import TooltipMUI, { TooltipProps } from '@mui/material/Tooltip';
+import Popover from '../Popover';
+import usePopover from '../Popover/usePopover';
 
 type ITooltipPlacement =
   | 'bottom-end'
@@ -17,39 +18,27 @@ type ITooltipPlacement =
   | 'top-start'
   | 'top';
 
-type ITooltipExtends = 'open' | 'onOpen' | 'onClose' | 'id';
-
-export interface ITooltipProps extends Pick<TooltipProps, ITooltipExtends> {
-  title: React.ReactNode;
+export interface ITooltipProps {
+  title?: React.ReactNode;
   placement?: ITooltipPlacement;
   disabled?: boolean;
   children: React.ReactNode;
   className?: string;
 }
 
-const Tooltip: React.FC<ITooltipProps> = ({ placement = 'top', children, disabled = false, className, ...rest }) => {
+const Tooltip = ({ children }: ITooltipProps) => {
+  const { openPopover, closePopover, popoverTargetProps, popoverProps } = usePopover();
+
   return (
-    <TooltipMUI
-      {...rest}
-      disableTouchListener={disabled}
-      disableHoverListener={disabled}
-      disableFocusListener={disabled}
-      placement={placement}
-      arrow
-    >
-      <Content children={children} className={className} />
-    </TooltipMUI>
+    <>
+      <Popover {...popoverProps} placement='bottom-start'>
+        <div>Eu sou o tooltip</div>
+      </Popover>
+      <span {...popoverTargetProps} onMouseEnter={openPopover} onMouseLeave={closePopover}>
+        {children}
+      </span>
+    </>
   );
 };
-
-const Content = React.forwardRef<HTMLDivElement, { children: React.ReactNode; className?: string }>(
-  ({ children, className, ...rest }, ref) => {
-    return (
-      <div className={className} {...rest} ref={ref} style={{ display: 'inline-flex' }}>
-        {children}
-      </div>
-    );
-  }
-);
 
 export default React.memo(Tooltip);

--- a/src/pages/ui-components/Tooltip/index.tsx
+++ b/src/pages/ui-components/Tooltip/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import styled, { css, IStyledProp } from '@eduzz/houston-styles';
-import Caption from '@eduzz/houston-ui/Typography/Caption';
+import { IStyledProp } from '@eduzz/houston-styles/styled';
 
 import Popover from '../Popover';
 import usePopover from '../Popover/usePopover';
+import TooltipBody from './TooltipBody';
 
 type ITooltipPlacement =
   | 'bottom-end'
@@ -20,92 +20,43 @@ type ITooltipPlacement =
   | 'top-start'
   | 'top';
 
-export interface ITooltipProps {
+export interface ITooltipProps extends IStyledProp {
   title?: React.ReactNode;
   placement?: ITooltipPlacement;
   disabled?: boolean;
   children: React.ReactNode;
-  className?: string;
+  id?: string;
+  onOpen?(): void;
+  onClose?(): void;
 }
 
-const TooltipBody = ({ className }: IStyledProp) => {
-  return (
-    <div className={className}>
-      <div id='arrow' data-popper-arrow></div>
-      <Caption color='neutralColor.high.pure'>Eu sou o tooltip </Caption>
-    </div>
-  );
-};
-
-const StyledTooltipBody = React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
-  ${({ theme }) => css`
-    padding: ${theme.spacing.inset.xxs};
-    border: ${theme.border.width.xs} solid;
-    border-radius: ${theme.border.radius.xs};
-    min-width: ${theme.spacing.xl};
-    background-color: ${theme.neutralColor.low.pure};
-
-    #arrow,
-    #arrow::before {
-      position: absolute;
-      width: 8px;
-      height: 8px;
-      background: inherit;
-      color: inherit;
-    }
-
-    #arrow {
-      visibility: hidden;
-    }
-
-    #arrow::before {
-      visibility: visible;
-      content: '';
-      transform: rotate(45deg);
-    }
-
-    &.--placement-top {
-      > #arrow {
-        bottom: -4px;
-      }
-    }
-
-    &.--placement-bottom {
-      > #arrow {
-        top: -4px;
-      }
-    }
-
-    &.--placement-left {
-      > #arrow {
-        right: -4px;
-      }
-    }
-
-    &.--placement-right {
-      > #arrow {
-        left: -4px;
-      }
-    }
-  `}
-`);
-
-const Tooltip = ({ children, placement }: ITooltipProps) => {
+const Tooltip = ({ children, placement = 'top', id: idProp, disabled, onOpen, onClose }: ITooltipProps) => {
   const { openPopover, closePopover, popoverTargetProps, popoverProps } = usePopover();
+
+  const [id] = React.useState(idProp ?? `${Math.floor(Math.random() * 100)}`);
+
+  const onOpenPopover = React.useCallback(() => {
+    onOpen && onOpen();
+    openPopover();
+  }, [onOpen, openPopover]);
+
+  const onClosePopover = React.useCallback(() => {
+    onClose && onClose();
+    closePopover();
+  }, [onClose, closePopover]);
 
   return (
     <>
-      <Popover {...popoverProps} placement={placement}>
-        <StyledTooltipBody className={`--placement-${placement}`} />
-      </Popover>
-      <div
-        {...popoverTargetProps}
-        tabIndex={0}
-        onMouseEnter={openPopover}
-        /* onMouseLeave={closePopover}*/
-      >
-        {children}
-      </div>
+      <>
+        {!disabled && (
+          <Popover {...popoverProps} placement={placement}>
+            <TooltipBody className={`--placement-${placement}`} />
+          </Popover>
+        )}
+        <span id={id} tabIndex={0} {...popoverTargetProps} onMouseEnter={onOpenPopover} onMouseLeave={onClosePopover}>
+          {children}
+        </span>
+      </>
     </>
   );
 };

--- a/src/pages/ui-components/Tooltip/index.tsx
+++ b/src/pages/ui-components/Tooltip/index.tsx
@@ -58,7 +58,7 @@ const Tooltip = ({ children, title, placement = 'top', id: idProp, disabled, onO
       <>
         {!disabled && isPopoverCreated && (
           <Popover id={id} {...popoverProps} placement={placement} variant='tooltip'>
-            <TooltipBody className={`--placement-${placement}`} title={title} />
+            <TooltipBody title={title} />
           </Popover>
         )}
         <span tabIndex={0} {...popoverTargetProps} onMouseEnter={onOpenPopover} onMouseLeave={onClosePopover}>


### PR DESCRIPTION
Breaking change : Removido open prop

Antes se clicasse no botão não sumia tooltip e agora está sumindo

![image](https://user-images.githubusercontent.com/17049866/177195549-2bccdab1-b842-4639-abe1-ae83466f0dd9.png)

Figma : https://www.figma.com/file/WJWEph4jRV7uuVe4e9Pj13/Desktop-components-handoff?node-id=638%3A16555
