### PR TITLE
Feat/tag highlight

### DIFF
--- a/src/pages/ui-components/TagHighlight/index.mdx
+++ b/src/pages/ui-components/TagHighlight/index.mdx
@@ -4,8 +4,8 @@ name: TagHighlight
 
 import { Playground } from 'dokz';
 
-import Row from '../Grid/Row';
 import Column from '../Grid/Column';
+import Row from '../Grid/Row';
 import TagHighlight from './';
 
 # TagHighlight

--- a/src/pages/ui-components/TagHighlight/index.mdx
+++ b/src/pages/ui-components/TagHighlight/index.mdx
@@ -1,0 +1,48 @@
+---
+name: TagHighlight
+---
+
+import { Playground } from 'dokz';
+
+import Row from '../Grid/Row';
+import Column from '../Grid/Column';
+import TagHighlight from './';
+
+# TagHighlight
+
+O componente TagHighlight é usado para destacar o status de um item.
+
+### Importação
+
+```js
+import TagHighlight from '@eduzz/houston-ui/TagHighlight';
+```
+
+### Exemplo
+
+<Playground>
+  <Row>
+    <Column>
+      <TagHighlight>Default</TagHighlight>
+    </Column>
+    <Column>
+      <TagHighlight variant='outlined'>Outlined</TagHighlight>
+    </Column>
+    <Column>
+      <TagHighlight color='feedbackColor.positive.medium'>Color Filled</TagHighlight>
+    </Column>
+    <Column>
+      <TagHighlight color='feedbackColor.positive.medium' variant='outlined'>
+        Color Outlined
+      </TagHighlight>
+    </Column>
+  </Row>
+</Playground>
+
+### TagHighlight props
+
+| prop     | tipo                | obrigatório | padrão   | descrição                                 |
+| -------- | ------------------- | ----------- | -------- | ----------------------------------------- |
+| children | `string`            | `true`      | -        | -                                         |
+| color    | `string`            | `false`     | `false`  | Precisa ser uma cor que esteja nos tokens |
+| variant  | `outlined I filled` | `false`     | `filled` | -                                         |

--- a/src/pages/ui-components/TagHighlight/index.tsx
+++ b/src/pages/ui-components/TagHighlight/index.tsx
@@ -14,7 +14,7 @@ const TagHighlight = ({ children, className, variant = 'filled', ...rest }: TagH
   </span>
 );
 
-function getColor(theme: HoustonThemeProps, color?: string) {
+function getColor(theme: HoustonThemeProps, color: string) {
   if (!color) return;
 
   if (color === 'inherit') {
@@ -37,24 +37,27 @@ function getColor(theme: HoustonThemeProps, color?: string) {
 
 const MAX_HEIGHT_IN_PIX = 22;
 
-export default styled(TagHighlight, { label: 'houston-tag-highlight' })(({ theme, color }) => {
-  console.log(color, 'color');
-  return css`
-    background-color: ${color ? getColor(theme, color) : theme.neutralColor.high.medium};
-    border-radius: ${theme.border.radius.pill};
-    padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
-    display: inline-flex;
-    align-items: center;
-    font-size: ${theme.font.size.xxs};
-    color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
-    line-height: ${theme.line.height.default};
-    max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PIX)}rem;
+export default styled(TagHighlight, { label: 'houston-tag-highlight' })(
+  ({ theme, color = 'neutralColor.high.medium' }) => {
+    const isDefaultColor = color === 'neutralColor.high.medium';
 
-    &.--outlined {
-      border: ${theme.border.width.xs} solid;
-      border-color: ${getColor(theme, color)};
-      color: ${getColor(theme, color)};
-      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
-    }
-  `;
-});
+    return css`
+      background-color: ${getColor(theme, color)};
+      border-radius: ${theme.border.radius.pill};
+      padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
+      display: inline-flex;
+      align-items: center;
+      font-size: ${theme.font.size.xxs};
+      color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
+      line-height: ${theme.line.height.default};
+      max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PIX)}rem;
+
+      &.--outlined {
+        border: ${theme.border.width.xs} solid;
+        border-color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
+        color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
+        background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+      }
+    `;
+  }
+);

--- a/src/pages/ui-components/TagHighlight/index.tsx
+++ b/src/pages/ui-components/TagHighlight/index.tsx
@@ -1,33 +1,59 @@
-import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
+import styled, { css, cx, HoustonThemeProps, StyledProp } from '@eduzz/houston-styles';
+
+import warning from '../utils/warning';
 
 export interface TagHighlightProps extends StyledProp, React.HTMLAttributes<HTMLSpanElement> {
   children: string;
-  color: string;
+  color?: string;
   variant?: 'outlined' | 'filled';
 }
 
-const TagHighlight = ({ children, className, color, variant = 'filled', ...rest }: TagHighlightProps) => (
+const TagHighlight = ({ children, className, variant = 'filled', ...rest }: TagHighlightProps) => (
   <span className={cx(className, `--${variant}`)} {...rest}>
     {children}
   </span>
 );
 
+function getColor(theme: HoustonThemeProps, color?: string) {
+  if (!color) return;
+
+  if (color === 'inherit') {
+    return 'inherit';
+  }
+
+  if (color === 'primary') {
+    return theme.brandColor.primary.pure;
+  }
+
+  const [themeColor, level, variable] = color.split('.');
+  const result = theme[themeColor]?.[level]?.[variable];
+
+  if (!result) {
+    warning('Typography', `invalid color ${color}`);
+  }
+
+  return result;
+}
+
 const MAX_HEIGHT_IN_PIX = 22;
 
-export default styled(TagHighlight, { label: 'houston-tag-highlight' })(({ theme }) => {
+export default styled(TagHighlight, { label: 'houston-tag-highlight' })(({ theme, color }) => {
+  console.log(color, 'color');
   return css`
-    background-color: ${theme.neutralColor.high.medium};
+    background-color: ${color ? getColor(theme, color) : theme.neutralColor.high.medium};
     border-radius: ${theme.border.radius.pill};
     padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
     display: inline-flex;
     align-items: center;
     font-size: ${theme.font.size.xxs};
+    color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
     line-height: ${theme.line.height.default};
     max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PIX)}rem;
 
     &.--outlined {
       border: ${theme.border.width.xs} solid;
-      border-color: ${theme.neutralColor.low.pure};
+      border-color: ${getColor(theme, color)};
+      color: ${getColor(theme, color)};
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
     }
   `;

--- a/src/pages/ui-components/TagHighlight/index.tsx
+++ b/src/pages/ui-components/TagHighlight/index.tsx
@@ -5,6 +5,9 @@ import warning from '../utils/warning';
 export interface TagHighlightProps extends StyledProp, React.HTMLAttributes<HTMLSpanElement> {
   children: string;
   color?: string;
+  /**
+   * Defaults to 'filled'
+   */
   variant?: 'outlined' | 'filled';
 }
 
@@ -35,7 +38,7 @@ function getColor(theme: HoustonThemeProps, color: string) {
   return result;
 }
 
-const MAX_HEIGHT_IN_PIX = 22;
+const MAX_HEIGHT_IN_PX = 22;
 
 export default styled(TagHighlight, { label: 'houston-tag-highlight' })(
   ({ theme, color = 'neutralColor.high.medium' }) => {
@@ -47,10 +50,12 @@ export default styled(TagHighlight, { label: 'houston-tag-highlight' })(
       padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
       display: inline-flex;
       align-items: center;
-      font-size: ${theme.font.size.xxs};
       color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
       line-height: ${theme.line.height.default};
-      max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PIX)}rem;
+      font-size: ${theme.font.size.xxs};
+      font-weight: ${theme.font.weight.regular};
+      font-family: ${theme.font.family.base};
+      max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PX)}rem;
 
       &.--outlined {
         border: ${theme.border.width.xs} solid;

--- a/src/pages/ui-components/TagHighlight/index.tsx
+++ b/src/pages/ui-components/TagHighlight/index.tsx
@@ -1,0 +1,34 @@
+import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
+
+export interface TagHighlightProps extends StyledProp, React.HTMLAttributes<HTMLSpanElement> {
+  children: string;
+  color: string;
+  variant?: 'outlined' | 'filled';
+}
+
+const TagHighlight = ({ children, className, color, variant = 'filled', ...rest }: TagHighlightProps) => (
+  <span className={cx(className, `--${variant}`)} {...rest}>
+    {children}
+  </span>
+);
+
+const MAX_HEIGHT_IN_PIX = 22;
+
+export default styled(TagHighlight, { label: 'houston-tag-highlight' })(({ theme }) => {
+  return css`
+    background-color: ${theme.neutralColor.high.medium};
+    border-radius: ${theme.border.radius.pill};
+    padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
+    display: inline-flex;
+    align-items: center;
+    font-size: ${theme.font.size.xxs};
+    line-height: ${theme.line.height.default};
+    max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PIX)}rem;
+
+    &.--outlined {
+      border: ${theme.border.width.xs} solid;
+      border-color: ${theme.neutralColor.low.pure};
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+    }
+  `;
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17049866/180105731-5e6d6884-0491-46c0-8edd-066185243463.png)

figma : https://www.figma.com/file/WJWEph4jRV7uuVe4e9Pj13/Desktop-components-handoff?node-id=2875%3A70966

A cor vai ser aberta, tentei tipar do jeito do Typography mas o ts ficou doidão, acho que o warning é suficente para avisar o cara que tá com cor inválida.
