### PR TITLE
Layout adjusts

### DIFF
--- a/src/dev/src/App.tsx
+++ b/src/dev/src/App.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { BrowserRouter } from 'react-router-dom';
 
 import InfoChatOutline from '@eduzz/houston-icons/InfoChatOutline';
@@ -21,10 +23,16 @@ declare module '@eduzz/houston-styles' {
 }
 
 function App() {
+  const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);
+
+  function toggleSidebar() {
+    setIsSidebarOpen(prevState => !prevState);
+  }
+
   return (
     <BrowserRouter>
       <ThemeProvider>
-        <Layout>
+        <Layout isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar}>
           <Topbar
             currentApplication='orbita'
             user={{

--- a/src/pages/ui-components/Breadcrumb/Link/index.tsx
+++ b/src/pages/ui-components/Breadcrumb/Link/index.tsx
@@ -6,6 +6,9 @@ import { useBreadcrumb } from '../context';
 import LongTextToolTip from '../internals/LongTextToolTip';
 
 type BreadcrumbLinkProps = {
+  /**
+   * Allow to provide more props to the `as` Component
+   */
   [key: string]: any;
   /**
    * Component that wraps the item.
@@ -16,9 +19,6 @@ type BreadcrumbLinkProps = {
    * Redirect path.
    */
   href?: string;
-  /**
-   * Allow to provide more props to the `as` Component
-   */
   icon?: React.ReactNode;
   children?: React.ReactNode;
 };

--- a/src/pages/ui-components/Layout/Layout.tsx
+++ b/src/pages/ui-components/Layout/Layout.tsx
@@ -13,9 +13,11 @@ import Topbar from './Topbar';
 
 export interface LayoutProps extends StyledProp {
   children?: React.ReactNode;
+  isSidebarOpen?: boolean;
+  toggleSidebar?: () => void;
 }
 
-const Layout = ({ className, children }: LayoutProps) => {
+const Layout = ({ className, children, isSidebarOpen: isSidebarOpenProp, toggleSidebar }: LayoutProps) => {
   const [hasTopbar, setHasTopbar] = React.useState(false);
   const [hasSidebar, setHasSidebar] = React.useState(false);
   const [hasUserMenu, setHasUserMenu] = React.useState(false);
@@ -51,9 +53,9 @@ const Layout = ({ className, children }: LayoutProps) => {
       },
       sidebar: {
         exists: hasSidebar,
-        opened: sidebarOpened,
+        opened: isSidebarOpenProp ?? sidebarOpened,
         register: registerSidebar,
-        toogleOpened: toogleSidebarOpened,
+        toogleOpened: toggleSidebar ?? toogleSidebarOpened,
         trueOpened: trueSidebarOpened,
         falseOpened: falseSidebarOpened
       },
@@ -69,6 +71,8 @@ const Layout = ({ className, children }: LayoutProps) => {
       }
     }),
     [
+      isSidebarOpenProp,
+      toggleSidebar,
       falseSidebarOpened,
       falseUserMenuOpened,
       hasSidebar,

--- a/src/pages/ui-components/Layout/Sidebar/index.tsx
+++ b/src/pages/ui-components/Layout/Sidebar/index.tsx
@@ -26,7 +26,7 @@ const Sidebar = ({ currentLocation, children, className }: SidebarProps) => {
   const hasTopbar = useContextSelector(LayoutContext, context => context.topbar.exists);
   const register = useContextSelector(LayoutContext, context => context.sidebar.register);
   const opened = useContextSelector(LayoutContext, context => context.sidebar.opened);
-  const closeMenu = useContextSelector(LayoutContext, context => context.sidebar.falseOpened);
+  const toggleMenu = useContextSelector(LayoutContext, context => context.sidebar.toogleOpened);
 
   React.useEffect(() => {
     const unregister = register();
@@ -43,7 +43,7 @@ const Sidebar = ({ currentLocation, children, className }: SidebarProps) => {
   return (
     <SidebarContext.Provider value={contextValue}>
       <div className={cx(className, { '--visible': opened && isMobile, '--has-topbar': hasTopbar })}>
-        <Overlay visible={opened && isMobile} color='high' onClick={closeMenu} underTopbar />
+        <Overlay visible={opened && isMobile} color='high' onClick={toggleMenu} underTopbar />
 
         <aside className='houston-menu__container'>
           <nav>

--- a/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
@@ -116,7 +116,7 @@ export default styled(Belt, { label: 'houston-topbar-belt' })(
         white-space: nowrap;
         text-transform: uppercase;
         font-style: italic;
-        margin-left: ${theme.spacing.nano};
+        margin-left: ${theme.spacing.inline.quarck};
       }
     }
 

--- a/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
@@ -114,8 +114,6 @@ export default styled(Belt, { label: 'houston-topbar-belt' })(
 
       & > .houston-topbar-belt__text {
         white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         text-transform: uppercase;
         font-style: italic;
         margin-left: ${theme.spacing.nano};

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
@@ -58,6 +58,7 @@ const UserMenuItem: React.FC<UserMenuItemProps> = ({
 
 export default styled(UserMenuItem, { label: 'houston-user-menu-item' })`
   justify-content: start;
+  text-align: left;
 
   &.--disabled {
     background-color: transparent;

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
@@ -8,14 +8,31 @@ import Button from '../../../../Button';
 import Typography from '../../../../Typography';
 import LayoutContext from '../../../context';
 
-export interface UserMenuItemProps extends StyledProp, Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'> {
+export interface UserMenuItemProps extends StyledProp {
+  /**
+   * Allow to provide more props to the `as` Component
+   */
+  [key: string]: any;
+  /**
+   * Component that wraps the item.
+   * @example a, NavLink, Link (react-router-dom)
+   */
+  as?: React.ElementType;
   icon?: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   disabled?: boolean;
   children: string;
 }
 
-const UserMenuItem: React.FC<UserMenuItemProps> = ({ className, icon, disabled, onClick, children, ...rest }) => {
+const UserMenuItem: React.FC<UserMenuItemProps> = ({
+  className,
+  icon,
+  disabled,
+  onClick,
+  children,
+  as: Tag,
+  ...rest
+}) => {
   const close = useContextSelector(LayoutContext, context => context.userMenu.falseOpened);
 
   const handleClick = React.useCallback(
@@ -32,8 +49,8 @@ const UserMenuItem: React.FC<UserMenuItemProps> = ({ className, icon, disabled, 
     </Button>
   );
 
-  if (rest.href) {
-    content = <a {...rest}>{content}</a>;
+  if (Tag) {
+    content = <Tag {...rest}>{content}</Tag>;
   }
 
   return <>{content}</>;

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/index.tsx
@@ -5,7 +5,7 @@ import { useContextSelector } from 'use-context-selector';
 import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
 
 import Portal from '../../../Portal';
-import LayoutContext, { TOPBAR_HEIGHT, TOPBAR_HEIGHT_MOBILE, TOPBAR_MENU_WIDTH } from '../../context';
+import LayoutContext, { TOPBAR_HEIGHT, TOPBAR_HEIGHT_MOBILE, TOPBAR_MENU_MIN_WIDTH_IN_PX } from '../../context';
 
 export interface UserMenuProps extends StyledProp {
   children: React.ReactNode;
@@ -32,7 +32,10 @@ const UserMenu: React.FC<UserMenuProps> = ({ className, children }) => {
 
 export default styled(UserMenu, { label: 'houston-topbar-user-menu' })(
   ({ theme }) => css`
-    width: ${TOPBAR_MENU_WIDTH}px;
+    display: flex;
+    flex-direction: column;
+    width: fit-content;
+    min-width: ${TOPBAR_MENU_MIN_WIDTH_IN_PX}px;
     position: fixed;
     top: ${TOPBAR_HEIGHT}px;
     right: ${theme.spacing.inline.nano};

--- a/src/pages/ui-components/Layout/Topbar/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/index.tsx
@@ -147,7 +147,6 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
 
         & .houston-topbar__mobile-menu {
           cursor: pointer;
-          margin: 0 -10px 0 -5px;
 
           ${breakpoints.up('lg')} {
             display: none;
@@ -157,11 +156,7 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
         & .houston-topbar__logo {
           height: 80%;
           width: auto;
-          margin-right: ${theme.spacing.inline.nano};
-
-          ${theme.breakpoints.up('md')} {
-            margin: 0 ${theme.spacing.inline.nano};
-          }
+          margin-inline: ${theme.spacing.inline.nano};
 
           & > img {
             max-width: 100%;
@@ -174,8 +169,7 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
           }
 
           ${breakpoints.down('sm')} {
-            width: 44px;
-            min-width: 40px;
+            width: 32px;
 
             & .houston-topbar__logo-default {
               display: none;

--- a/src/pages/ui-components/Layout/context.ts
+++ b/src/pages/ui-components/Layout/context.ts
@@ -3,7 +3,7 @@ import { createContext } from 'use-context-selector';
 export const TOPBAR_HEIGHT = 80;
 export const TOPBAR_HEIGHT_MOBILE = 64;
 export const TOPBAR_DROPDOWN_WIDTH = 340;
-export const TOPBAR_MENU_WIDTH = 260;
+export const TOPBAR_MENU_MIN_WIDTH_IN_PX = 260;
 
 export const MENU_WIDTH = 248;
 


### PR DESCRIPTION
Mudanças (lembrando que foram passadas com o Milton):
- Correção do espaçamento dos itens da esquerda da Topbar
- Correção do belt estava cortando o T;
- Correção do espaçamento do texto belt;
- Agora é possível controlar o estado da Sidebar;
- Agora o UserMenu se ajusta ao tamanho do conteúdo dele, mas também o tamanho mínimo de 260px;
- Agora o UserMenuItem aceita uma propriedade `as`, para que possamos usar NavLink, etc;