### PR TITLE
Add collapse on tabs

### DIFF
--- a/src/pages/ui-components/IconButton/index.tsx
+++ b/src/pages/ui-components/IconButton/index.tsx
@@ -32,12 +32,12 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     <button
       role='button'
       disabled={disabled}
-      className={cx(className, `--${size ?? 'lg'}`, { '--active': active })}
+      className={cx(className, `--hst-${size ?? 'lg'}`, { '--hst-active': active })}
       aria-disabled={disabled}
       {...rest}
       ref={ref}
     >
-      <div className={cx('__icon', `--${size ?? 'lg'}`, { '--disabled': disabled })}>{children}</div>
+      <div className={cx('__hst-icon', `--hst-${size ?? 'lg'}`, { '--hst-disabled': disabled })}>{children}</div>
     </button>
   )
 );
@@ -62,15 +62,15 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
       transition: 0.3s;
     }
 
-    &.--lg,
-    &.--large {
+    &.--hst-lg,
+    &.--hst-large {
       width: ${theme.pxToRem(LG_SIZE)}rem;
       height: ${theme.pxToRem(LG_SIZE)}rem;
     }
 
-    &.--md,
-    &.--medium,
-    &.--small {
+    &.--hst-md,
+    &.--hst-medium,
+    &.--hst-small {
       width: ${theme.pxToRem(MD_SIZE)}rem;
       height: ${theme.pxToRem(MD_SIZE)}rem;
     }
@@ -79,17 +79,18 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
       cursor: default;
     }
 
-    .__icon {
+    .__hst-icon {
       display: flex;
       align-items: center;
       justify-content: center;
 
-      &.--disabled {
+      &.--hst-disabled {
         fill: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
+        color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
       }
 
-      &.--lg,
-      &.--large {
+      &.--hst-lg,
+      &.--hst-large {
         width: ${theme.pxToRem(LG_ICON_SIZE)}rem;
         height: ${theme.pxToRem(LG_ICON_SIZE)}rem;
 
@@ -99,9 +100,9 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
         }
       }
 
-      &.--md,
-      &.--medium,
-      &.--small {
+      &.--hst-md,
+      &.--hst-medium,
+      &.--hst-small {
         width: ${theme.pxToRem(MD_ICON_SIZE)}rem;
         height: ${theme.pxToRem(MD_ICON_SIZE)}rem;
 
@@ -118,7 +119,7 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
 
     &:hover:not(:disabled),
     &:focus,
-    &.--active {
+    &.--hst-active {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
     }
   `}

--- a/src/pages/ui-components/Tabs/Vertical/index.mdx
+++ b/src/pages/ui-components/Tabs/Vertical/index.mdx
@@ -62,10 +62,12 @@ Não há necessidade de controlar o estado da aba ativa.
 
 ### Tabs props
 
-| prop     | type                      | required | default | description         |
-| -------- | ------------------------- | -------- | ------- | ------------------- |
-| value    | `number`                  | `false`  | -       | Índice da aba.      |
-| onChange | `(value: number) => void` | `false`  | -       | Recebe novo índice. |
+| prop           | type                      | required | default | description                                                                              |
+| -------------- | ------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| value          | `number`                  | `false`  | -       | Índice da aba.                                                                           |
+| onChange       | `(value: number) => void` | `false`  | -       | Recebe novo índice.                                                                      |
+| destroyOnClose | `boolean`                 | `false`  | `false` | Se true o componente que está dentro da Tab será desmontado depois que a Tab for trocada |
+| mountOnEnter   | `boolean`                 | `false`  | `false` | Se true o componente que está dentro da Tab só sera montado depois que a Tab for trocada |
 
 ### Tab props
 

--- a/src/pages/ui-components/Tabs/Vertical/index.tsx
+++ b/src/pages/ui-components/Tabs/Vertical/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
+import Collapse from '@eduzz/houston-ui/Collapse';
 
 import { useChildrenProps, useChildrenComponent } from '../../hooks/useChildrenProps';
 import Tab from '../Tab';
@@ -10,15 +11,24 @@ export interface TabsProps extends StyledProp, Omit<React.HTMLAttributes<HTMLDiv
   children: React.ReactNode;
   value?: number;
   onChange?: (value: number) => void;
+  destroyOnClose?: boolean;
+  mountOnEnter?: boolean;
 }
 
-const Tabs = ({ children, value, onChange, ...rest }: TabsProps) => {
+const Tabs = ({ children, value, onChange, destroyOnClose, mountOnEnter, ...rest }: TabsProps) => {
   const childrenProps = useChildrenProps(children, Tab);
   const tabs = useChildrenComponent(children, Tab);
 
   const { passRefsToArray, steps, sizes } = useTabSteps('vertical');
 
   const [activeTab, setActiveTab] = React.useState(value ?? 0);
+  const controlled = typeof value !== 'undefined';
+
+  React.useEffect(() => {
+    if (controlled) {
+      setActiveTab(value);
+    }
+  }, [controlled, value]);
 
   const labelsRef = React.useRef<HTMLDivElement>(null);
 
@@ -50,13 +60,26 @@ const Tabs = ({ children, value, onChange, ...rest }: TabsProps) => {
         <span
           className='hst-tabs-vertical__slider'
           style={{
-            height: sizes[value ?? activeTab],
-            top: steps[value ?? activeTab],
+            height: sizes[activeTab],
+            top: steps[activeTab],
             left: labelsRef.current?.getBoundingClientRect().width
           }}
         />
       </div>
-      <div className='hst-tabs-vertical-content'>{tabs[value ?? activeTab].props.children}</div>
+
+      <div className='hst-tabs-vertical-content'>
+        {tabs?.map((tab, index) => (
+          <Collapse
+            key={index}
+            timeout={0}
+            visibled={activeTab === index}
+            destroyOnClose={destroyOnClose}
+            mountOnEnter={mountOnEnter}
+          >
+            {tab.props.children}
+          </Collapse>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/pages/ui-components/Tabs/index.mdx
+++ b/src/pages/ui-components/Tabs/index.mdx
@@ -94,19 +94,6 @@ Não há necessidade de controlar o estado da aba ativa.
   }}
 </Playground>
 
-### Com ícone
-
-<Playground>
-  <Tabs>
-    <Tabs.Content label='Título 1' icon={<FaceHappyOutline />}>
-      <div>Conteúdo 1</div>
-    </Tabs.Content>
-    <Tabs.Content label='Título 2' icon={<FaceHappyOutline />}>
-      <div>Conteúdo 2</div>
-    </Tabs.Content>
-  </Tabs>
-</Playground>
-
 #### Tabs props
 
 | prop     | type                      | required | default | description         |

--- a/src/pages/ui-components/Tabs/index.mdx
+++ b/src/pages/ui-components/Tabs/index.mdx
@@ -5,8 +5,6 @@ name: Tabs
 import { Playground } from 'dokz';
 
 import FaceHappyOutline from '@eduzz/houston-icons/FaceHappyOutline';
-import Image from '@eduzz/houston-ui/Image';
-
 import Tabs from './';
 
 # Tabs
@@ -96,10 +94,12 @@ Não há necessidade de controlar o estado da aba ativa.
 
 #### Tabs props
 
-| prop     | type                      | required | default | description         |
-| -------- | ------------------------- | -------- | ------- | ------------------- |
-| value    | `number`                  | `false`  | -       | Índice da aba.      |
-| onChange | `(value: number) => void` | `false`  | -       | Recebe novo índice. |
+| prop           | type                      | required | default | description                                                                              |
+| -------------- | ------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| value          | `number`                  | `false`  | -       | Índice da aba.                                                                           |
+| onChange       | `(value: number) => void` | `false`  | -       | Recebe novo índice.                                                                      |
+| destroyOnClose | `boolean`                 | `false`  | `false` | Se true o componente que está dentro da Tab será desmontado depois que a Tab for trocada |
+| mountOnEnter   | `boolean`                 | `false`  | `false` | Se true o componente que está dentro da Tab só sera montado depois que a Tab for trocada |
 
 ### Tab props
 

--- a/src/pages/ui-components/Tabs/index.tsx
+++ b/src/pages/ui-components/Tabs/index.tsx
@@ -151,7 +151,17 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
             </Select.Option>
           ))}
         </Select>
-        <div>{tabs[activeTab].props.children}</div>
+        {tabs?.map((tab, index) => (
+          <Collapse
+            key={index}
+            timeout={0}
+            visibled={activeTab === index}
+            destroyOnClose={destroyOnClose}
+            mountOnEnter={mountOnEnter}
+          >
+            <div>{tab.props.children}</div>
+          </Collapse>
+        ))}
       </>
     );
   }

--- a/src/pages/ui-components/Tabs/index.tsx
+++ b/src/pages/ui-components/Tabs/index.tsx
@@ -50,13 +50,15 @@ const Tabs = ({ children, value, onChange, selectOnMobile, ...rest }: TabsProps)
       const labelsWidth = labelsRef?.current?.clientWidth as number;
 
       labelsScrollWidth > labelsWidth ? setIsOverflowed(true) : setIsOverflowed(false);
+
+      handleScrollArrows();
     };
 
     handleResize();
     window.addEventListener('resize', handleResize);
 
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [handleScrollArrows]);
 
   const scrollBy = React.useCallback((position: 'right' | 'left', value: number) => {
     const goToRight = value;
@@ -254,6 +256,7 @@ const TabsWrapper = React.memo(
         transition-duration: 0.5s;
         transition-property: background-color, color;
         margin-bottom: ${NEGATIVE_SPACING_IN_PX}px;
+        cursor: pointer;
 
         :hover {
           background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};


### PR DESCRIPTION
**Bugs corrigidos :** 

1-)Flechas na Tab horizontal continuavam desativadas quando eram pra estar ativadas, isso ocorria quando diminuindo a tela de tamanho. Coloquei pra calcular se as flechas devem estar desativadas no evento de resize window.

2-) Quando clicando no Ícone do Tab não dava trigger no click da Tab, arrumei isso dando um : 

        > svg {
          pointer-events: none;
        }
        
Não sei porque mas isso arruma.

3-) IconButton estava sem os prefixos hst nas classes e tava dando conflito com as classes do orbita, agora está com os prefixos

**Features :** 

Adicionado mountOnEnter e destroyOnClose nas Tabs, está agora igual ao Accordion

