### PR TITLE
Atualização nas classes

### DIFF
--- a/src/dev/src/App.tsx
+++ b/src/dev/src/App.tsx
@@ -46,10 +46,10 @@ function App() {
               <Topbar.UserMenuItem>Minhas Compras</Topbar.UserMenuItem>
 
               <Topbar.UserMenuGroup label='Contas:'>
-                <Topbar.UserMenuItem href='http://google.com' target='_blank'>
+                <Topbar.UserMenuItem disabled href='http://google.com' target='_blank'>
                   John Doe
                 </Topbar.UserMenuItem>
-                <Topbar.UserMenuItem disabled>John Doe 2</Topbar.UserMenuItem>
+                <Topbar.UserMenuItem>John Doe 2</Topbar.UserMenuItem>
               </Topbar.UserMenuGroup>
 
               <Topbar.UserMenuDivider />

--- a/src/pages/ui-components/Accordion/Item/Content/index.tsx
+++ b/src/pages/ui-components/Accordion/Item/Content/index.tsx
@@ -16,7 +16,6 @@ const AccordionContent = ({ children, ...rest }: ContentProps) => {
   const expandedItems = useContextSelector(AccordionContext, context => context.expandedItems);
   const destroyOnClose = useContextSelector(AccordionContext, context => context.destroyOnClose);
   const mountOnEnter = useContextSelector(AccordionContext, context => context.mountOnEnter);
-
   const itemId = useContextSelector(ItemContext, context => context.itemId);
 
   const isExpanded = expandedItems.includes(itemId);

--- a/src/pages/ui-components/Accordion/Item/Title/index.tsx
+++ b/src/pages/ui-components/Accordion/Item/Title/index.tsx
@@ -37,7 +37,8 @@ const AccordionTitle = ({ children, ...rest }: TitleProps) => {
         ) : (
           <>{children}</>
         )}
-        <span className={cx('hst-accordion__icon', { '--isExpanded': expandedItems.includes(itemId) })}>
+
+        <span className={cx('hst-accordion-icon', { 'hst-accordion-expanded': expandedItems.includes(itemId) })}>
           <ChevronIcon />
         </span>
       </div>
@@ -55,12 +56,12 @@ export default styled(AccordionTitle, { label: 'hst-accordion-title' })(({ theme
     transition-duration: 0.5s;
     transition-property: background-color, color;
 
-    .hst-accordion__icon {
+    .hst-accordion-icon {
       line-height: 0;
       margin-left: auto;
       transition: 0.15s linear;
 
-      &.--isExpanded {
+      &.hst-accordion-expanded {
         transform: rotateX(180deg);
       }
     }

--- a/src/pages/ui-components/Accordion/Item/index.tsx
+++ b/src/pages/ui-components/Accordion/Item/index.tsx
@@ -10,6 +10,7 @@ import { ItemProvider } from './context';
 type ReceivedFromParentProps = {
   index?: number;
 };
+
 export interface ItemProps extends React.HTMLAttributes<HTMLDivElement>, ReceivedFromParentProps {
   children: React.ReactNode;
   disabled?: boolean;
@@ -24,7 +25,7 @@ const AccordionItem = ({ children, className, disabled, index, ...rest }: ItemPr
 
   return (
     <ItemProvider itemId={index as number}>
-      <div className={cx(className, { '--disabled': disabled })} {...rest} onClick={onClick}>
+      <div className={cx(className, { 'hst-accordion-disabled': disabled })} {...rest} onClick={onClick}>
         {children}
       </div>
     </ItemProvider>
@@ -33,7 +34,7 @@ const AccordionItem = ({ children, className, disabled, index, ...rest }: ItemPr
 
 const AccordionItemWrapper = styled(AccordionItem, { label: 'hst-accordion-item' })(({ theme }) => {
   return css`
-    &.--disabled {
+    &.hst-accordion-disabled {
       opacity: ${theme.opacity.level[6]};
       pointer-events: none;
     }

--- a/src/pages/ui-components/Accordion/index.mdx
+++ b/src/pages/ui-components/Accordion/index.mdx
@@ -6,9 +6,9 @@ import { Playground } from 'dokz';
 
 import Accordion from './';
 
-# Accordions
+# Accordion
 
-O Accordions é um elemento se expande no local para expor informações ocultas.
+O Accordion é um elemento se expande no local para expor informações ocultas.
 
 ### Importação
 
@@ -41,7 +41,7 @@ import Accordion from '@eduzz/houston-ui/Accordion';
   </Accordion>
 </Playground>
 
-### Valor controlado, allowMultiple = false e disabled
+### Valor controlado
 
 <Playground>
   {() => {
@@ -73,14 +73,14 @@ import Accordion from '@eduzz/houston-ui/Accordion';
 
 ### Accordion props
 
-| prop           | tipo                          | obrigatório | padrão  | descrição                                                                                               |
-| -------------- | ----------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| children       | `React.ReactNode`             | `true`      | -       | -                                                                                                       |
-| values         | `number[]`                    | `false`     | -       | Índices dos items que serão expandidos                                                                  |
-| onChange       | `(values: number[]) => void;` | `false`     | -       | Passa pelo callback os índices dos items que estão expandidos                                           |
-| allowMultiple  | `boolean`                     | `false`     | `true`  | Se false apenas um item poderá ser expandido                                                            |
-| destroyOnClose | `boolean`                     | `false`     | `false` | Se true o componente que está dentro do Accordion.Content será desmontado depois que o item for fechado |
-| mountOnEnter   | `boolean`                     | `false`     | `false` | Se true o componente que está dentro do Accordion.Content só sera montado depois que o item for aberto  |
+| prop           | tipo              | obrigatório | padrão  | descrição                                                                                               |
+| -------------- | ----------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| children       | `React.ReactNode` | `true`      | -       | -                                                                                                       |
+| values         | `number[]`        | `false`     | -       | Índices dos items que serão expandidos                                                                  |
+| onChange       | `function`        | `false`     | -       | Passa pelo callback os índices dos items que estão expandidos                                           |
+| allowMultiple  | `boolean`         | `false`     | `true`  | Se false apenas um item poderá ser expandido                                                            |
+| destroyOnClose | `boolean`         | `false`     | `false` | Se true o componente que está dentro do Accordion.Content será desmontado depois que o item for fechado |
+| mountOnEnter   | `boolean`         | `false`     | `false` | Se true o componente que está dentro do Accordion.Content só sera montado depois que o item for aberto  |
 
 ### Accordion.Item props
 

--- a/src/pages/ui-components/Accordion/index.tsx
+++ b/src/pages/ui-components/Accordion/index.tsx
@@ -52,7 +52,7 @@ const Accordion = ({
     }
   }, [controlled, values]);
 
-  const mappedChildren = React.Children.map(children, (child, i: number) => {
+  const mappedChildren = React.Children.map(children, (child, i) => {
     return React.cloneElement(child, {
       index: i
     });

--- a/src/pages/ui-components/Alert/Alert.tsx
+++ b/src/pages/ui-components/Alert/Alert.tsx
@@ -86,39 +86,44 @@ const Alert = React.forwardRef<HTMLDivElement, AlertInterface>(
     }
 
     return (
-      <div {...rest} ref={ref} role='alert' className={cx(className, `--type-${type}`, { '--close-icon': closeIcon })}>
-        <span role='img' className='__icon'>
+      <div
+        {...rest}
+        ref={ref}
+        role='alert'
+        className={cx(className, `hst-alert-type-${type}`, { 'hst-alert-close-icon': closeIcon })}
+      >
+        <span role='img' className='hst-alert-icon'>
           {IconMap[type]}
         </span>
 
-        <div className='__wrapper'>
-          <div className='__content'>
+        <div className='hst-alert-wrapper'>
+          <div className='hst-alert-content'>
             {title && (
               <Typography
                 color='neutralColor.low.pure'
                 weight='semibold'
                 size='md'
                 lineHeight='default'
-                className='__title'
+                className='hst-alert-title'
               >
                 {title}
               </Typography>
             )}
 
-            <Typography.Paragraph color='neutralColor.low.pure' size='sm' lineHeight='lg'>
+            <Typography.Paragraph color='neutralColor.low.pure' size='md' lineHeight='lg'>
               {children}
             </Typography.Paragraph>
           </div>
 
           {!!buttonText && (
-            <div className='__action'>
+            <div className='hst-alert-action'>
               <Button {...buttonProps}>{buttonText}</Button>
             </div>
           )}
         </div>
 
         {closeIcon && (
-          <span role='button' className='__close' onClick={handleClose}>
+          <span role='button' className='hst-alert-close' onClick={handleClose}>
             <Icon.Close />
           </span>
         )}
@@ -127,17 +132,17 @@ const Alert = React.forwardRef<HTMLDivElement, AlertInterface>(
   }
 );
 
-export default styled(Alert, { label: 'houston-alert' })`
+export default styled(Alert, { label: 'hst-alert' })`
   ${({ theme }) => {
     const mobileSpacingCloseIcon = theme.remToPx(theme.cleanUnit(theme.spacing.inline.nano)) + CLOSE_ICON_SIZE;
     const modifiersTypes: CSSInterpolation[] = [];
 
     Object.keys(theme.feedbackColor).forEach(key =>
       modifiersTypes.push(css`
-        &.--type-${key} {
+        &.hst-alert-type-${key} {
           background-color: ${theme.feedbackColor[key].light};
 
-          .__icon svg {
+          .hst-alert-icon svg {
             fill: ${theme.feedbackColor[key].pure};
           }
         }
@@ -157,12 +162,12 @@ export default styled(Alert, { label: 'houston-alert' })`
       }
 
       ${theme.breakpoints.down('md')} {
-        &.--close-icon {
-          .__content {
+        &.hst-alert-close-icon {
+          .hst-alert-content {
             margin-right: ${theme.pxToRem(mobileSpacingCloseIcon)}rem;
           }
 
-          .__close {
+          .hst-alert-close {
             position: absolute;
             top: ${theme.spacing.inset.xs};
             right: ${theme.spacing.inset.xs};
@@ -173,7 +178,7 @@ export default styled(Alert, { label: 'houston-alert' })`
 
       ${modifiersTypes}
 
-      .__icon {
+      .hst-alert-icon {
         line-height: 0;
         margin: ${theme.pxToRem(2)}rem ${theme.spacing.inline.xxxs} 0 0;
 
@@ -182,10 +187,10 @@ export default styled(Alert, { label: 'houston-alert' })`
         }
       }
 
-      .__wrapper {
+      .hst-alert-wrapper {
         flex: 1;
 
-        .__title {
+        .hst-alert-title {
           margin-bottom: ${theme.spacing.stack.xxxs};
 
           ${theme.breakpoints.down('md')} {
@@ -194,20 +199,20 @@ export default styled(Alert, { label: 'houston-alert' })`
           }
         }
 
-        .__action {
+        .hst-alert-action {
           margin-top: ${theme.spacing.stack.xxxs};
 
           ${theme.breakpoints.down('md')} {
             margin-top: ${theme.spacing.stack.xxs};
 
-            button {
+            button.hst-button {
               width: 100%;
             }
           }
         }
       }
 
-      .__close {
+      .hst-alert-close {
         line-height: 0;
         margin: ${theme.pxToRem(4)}rem 0 0 ${theme.spacing.inline.xxxs};
         cursor: pointer;

--- a/src/pages/ui-components/Avatar/index.mdx
+++ b/src/pages/ui-components/Avatar/index.mdx
@@ -24,16 +24,16 @@ Os tamanhos dísponiveis são: `xs`, `sm`, `md`, `lg `.
 
 <Playground>
   <Row alignItems='center'>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='xs' />
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='sm' />
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='md' />
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='lg' />
     </Column>
   </Row>
@@ -47,13 +47,13 @@ Existem três tipos: ícone (padrão), texto e imagem.
 
 <Playground>
   <Row alignItems='center'>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='lg' />
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='lg'>M</Avatar>
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Avatar size='lg' src='https://www.fillmurray.com/100/100' />
     </Column>
   </Row>
@@ -61,42 +61,9 @@ Existem três tipos: ícone (padrão), texto e imagem.
 
 > O tipo texto é considerado se o `children` for do tipo `string` (igual o exemplo acima).
 
-> Use a prop `alt` para espeficiar o texto alternativo para imagem.
-
-### Cores
-
-Há possibilidade de inverter as cores para dar suporte a contextos específicos. As cores dísponiveis são: `primary` (padrão) e `high`.
-
-<Playground>
-  <Row alignItems='center' className='bg-dark' style={{ paddingBottom: 16 }}>
-    <Column>
-      <Avatar size='lg' />
-    </Column>
-    <Column>
-      <Avatar size='lg'>M</Avatar>
-    </Column>
-    <Column>
-      <Avatar size='lg' src='https://www.fillmurray.com/100/100' />
-    </Column>
-    <Column>
-      <Avatar size='lg' color='high' />
-    </Column>
-    <Column>
-      <Avatar size='lg' color='high'>
-        M
-      </Avatar>
-    </Column>
-    <Column>
-      <Avatar size='lg' color='high' src='https://www.fillmurray.com/100/100' />
-    </Column>
-  </Row>
-</Playground>
-
 ## Propriedades
 
-| prop  | tipo           | obrigatório | padrão    | descrição                                   |
-| ----- | -------------- | ----------- | --------- | ------------------------------------------- |
-| src   | `string`       | `false`     | -         | Caminho da imagem.                          |
-| alt   | `string`       | `false`     | -         | Texto alternativo quando não houver imagem. |
-| size  | `IAvatarSize`  | `false`     | `md`      | -                                           |
-| color | `IAvatarColor` | `false`     | `primary` | -                                           |
+| prop | tipo          | obrigatório | padrão | descrição          |
+| ---- | ------------- | ----------- | ------ | ------------------ |
+| src  | `string`      | `false`     | -      | Caminho da imagem. |
+| size | `IAvatarSize` | `false`     | `md`   | -                  |

--- a/src/pages/ui-components/Avatar/index.tsx
+++ b/src/pages/ui-components/Avatar/index.tsx
@@ -4,8 +4,6 @@ import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
 
 export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
 
-export type AvatarColor = 'primary' | 'high';
-
 type SizesMap = Record<AvatarSize, string>;
 
 type FontMap = Record<AvatarSize, string>;
@@ -21,11 +19,6 @@ const AvatarIcon = () => (
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement>, StyledProp {
   src?: string;
-  alt?: string;
-  /**
-   * Default `primary`
-   */
-  color?: AvatarColor;
   /**
    * Default `md`
    */
@@ -33,18 +26,18 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement>, Style
   children?: React.ReactNode;
 }
 
-const Avatar = ({ src, alt, children, className, color = 'primary', size = 'md', ...rest }: AvatarProps) => {
+const Avatar = ({ src, children, className, size = 'md', ...rest }: AvatarProps) => {
   const hasImage = !!src;
   const hasText = typeof children === 'string';
 
   const firstLetter = (hasText && children?.[0]?.trim()) ?? ' ';
 
   return (
-    <span className={cx(className, `--${color}`, `--${size}`)} {...rest}>
-      {hasImage && <img src={src} alt={alt} />}
-      {!hasImage && hasText && <span className='houston-avatar__text'>{firstLetter}</span>}
+    <span className={cx(className, `hst-avatar-size-${size}`)} {...rest}>
+      {hasImage && <img className='hst-avatar-image' src={src} alt='Avatar' />}
+      {!hasImage && hasText && <span className='hst-avatar-text'>{firstLetter}</span>}
       {!hasImage && !hasText && (
-        <span className='houston-avatar__icon' role='img' aria-label='usuário'>
+        <span className='hst-avatar-icon' role='img' aria-label='usuário'>
           <AvatarIcon />
         </span>
       )}
@@ -52,7 +45,7 @@ const Avatar = ({ src, alt, children, className, color = 'primary', size = 'md',
   );
 };
 
-export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme }) => {
+export default styled(React.memo(Avatar), { label: 'hst-avatar' })(({ theme }) => {
   const fontMap: FontMap = {
     xs: theme.font.size.xxs,
     sm: theme.font.size.sm,
@@ -61,22 +54,22 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
   };
 
   return css`
-    color: white;
+    color: ${theme.neutralColor.high.pure};
     overflow: hidden;
-    border-radius: 50%;
+    border-radius: ${theme.border.radius.circular};
     display: inline-flex;
     vertical-align: middle;
     justify-content: center;
     background-color: ${theme.brandColor.primary.pure};
 
-    img {
+    img.hst-avatar-image {
       width: 100%;
       height: 100%;
       display: block;
       object-fit: cover;
     }
 
-    &.--xs {
+    &.hst-avatar-size-xs {
       width: ${sizesMap.xs};
       height: ${sizesMap.xs};
       min-width: ${sizesMap.xs};
@@ -84,13 +77,13 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       max-width: ${sizesMap.xs};
       max-height: ${sizesMap.xs};
 
-      .houston-avatar__text {
+      .hst-avatar-text {
         font-size: ${fontMap.xs};
         line-height: ${fontMap.xs};
       }
     }
 
-    &.--sm {
+    &.hst-avatar-size-sm {
       width: ${sizesMap.sm};
       height: ${sizesMap.sm};
       min-width: ${sizesMap.sm};
@@ -98,13 +91,13 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       max-width: ${sizesMap.sm};
       max-height: ${sizesMap.sm};
 
-      .houston-avatar__text {
+      .hst-avatar-text {
         font-size: ${fontMap.sm};
         line-height: ${fontMap.sm};
       }
     }
 
-    &.--md {
+    &.hst-avatar-size-md {
       width: ${sizesMap.md};
       height: ${sizesMap.md};
       min-width: ${sizesMap.md};
@@ -112,13 +105,13 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       max-width: ${sizesMap.md};
       max-height: ${sizesMap.md};
 
-      .houston-avatar__text {
+      .hst-avatar-text {
         font-size: ${fontMap.md};
         line-height: ${fontMap.md};
       }
     }
 
-    &.--lg {
+    &.hst-avatar-size-lg {
       width: ${sizesMap.lg};
       height: ${sizesMap.lg};
       min-width: ${sizesMap.lg};
@@ -126,22 +119,13 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       max-width: ${sizesMap.lg};
       max-height: ${sizesMap.lg};
 
-      .houston-avatar__text {
+      .hst-avatar-text {
         font-size: ${fontMap.lg};
         line-height: ${fontMap.lg};
       }
     }
 
-    &.--high {
-      color: ${theme.brandColor.primary.pure};
-      background-color: ${theme.neutralColor.high.pure};
-
-      .houston-avatar__icon svg {
-        fill: ${theme.brandColor.primary.pure};
-      }
-    }
-
-    .houston-avatar__text {
+    .hst-avatar-text {
       width: 100%;
       height: 100%;
       display: flex;
@@ -152,7 +136,7 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       user-select: none;
     }
 
-    .houston-avatar__icon {
+    .hst-avatar-icon {
       width: 100%;
       height: 100%;
       display: flex;
@@ -160,7 +144,7 @@ export default styled(React.memo(Avatar), { label: 'houston-avatar' })(({ theme 
       justify-content: center;
 
       svg {
-        fill: white;
+        fill: ${theme.neutralColor.high.pure};
         width: 100%;
       }
     }

--- a/src/pages/ui-components/Badge/index.tsx
+++ b/src/pages/ui-components/Badge/index.tsx
@@ -44,14 +44,14 @@ const Badge = ({
       {...rest}
       className={cx(
         className,
-        `--hst-badge-color-${color}`,
-        `--hst-badge-offset-${offset}`,
-        { '--hst-badge-has-not-children': !hasChildren },
-        { '--hst-badge-dot': dot || !hasCount },
-        { '--hst-badge-number': hasCount && !dot }
+        `hst-badge-color-${color}`,
+        `hst-badge-offset-${offset}`,
+        { 'hst-badge-has-not-children': !hasChildren },
+        { 'hst-badge-dot': dot || !hasCount },
+        { 'hst-badge-number': hasCount && !dot }
       )}
     >
-      <sup className='hst-badge__count'>{!dot && displayCount}</sup>
+      <sup className='hst-badge-count'>{!dot && displayCount}</sup>
       {children}
     </span>
   );
@@ -64,8 +64,8 @@ const BadgeWrapper = styled(Badge, { label: 'hst-badge' })`
     Object.keys(theme.feedbackColor).forEach(key => {
       if (key === 'warning') {
         return modifiers.push(css`
-          &.--hst-badge-color-warning {
-            & > .hst-badge__count {
+          &.hst-badge-color-warning {
+            & > .hst-badge-count {
               background-color: ${theme.feedbackColor[key].dark};
             }
           }
@@ -73,8 +73,8 @@ const BadgeWrapper = styled(Badge, { label: 'hst-badge' })`
       }
 
       return modifiers.push(css`
-        &.--hst-badge-color-${key} {
-          & > .hst-badge__count {
+        &.hst-badge-color-${key} {
+          & > .hst-badge-count {
             background-color: ${theme.feedbackColor[key].pure};
           }
         }
@@ -89,47 +89,47 @@ const BadgeWrapper = styled(Badge, { label: 'hst-badge' })`
 
       ${modifiers}
 
-      &.--hst-badge-dot {
-        & > .hst-badge__count {
+      &.hst-badge-dot {
+        & > .hst-badge-count {
           min-width: ${theme.pxToRem(MIN_WITH_DOT)}rem;
           height: ${theme.pxToRem(MIN_WITH_DOT)}rem;
           padding: 0;
         }
       }
 
-      &.--hst-badge-number {
-        & > .hst-badge__count {
+      &.hst-badge-number {
+        & > .hst-badge-count {
           min-width: ${theme.pxToRem(MIN_WITH_NUMBER)}rem;
           min-height: ${theme.pxToRem(MIN_WITH_NUMBER)}rem;
         }
       }
 
-      &.--hst-badge-offset-xs {
-        & > .hst-badge__count {
+      &.hst-badge-offset-xs {
+        & > .hst-badge-count {
           transform: translate(30%, -30%);
         }
       }
 
-      &.--hst-badge-offset-sm {
-        & > .hst-badge__count {
+      &.hst-badge-offset-sm {
+        & > .hst-badge-count {
           transform: translate(40%, -40%);
         }
       }
 
-      &.--hst-badge-offset-md {
-        & > .hst-badge__count {
+      &.hst-badge-offset-md {
+        & > .hst-badge-count {
           transform: translate(50%, -50%);
         }
       }
 
-      &.--hst-badge-has-not-children {
-        & > .hst-badge__count {
+      &.hst-badge-has-not-children {
+        & > .hst-badge-count {
           position: relative;
           transform: none;
         }
       }
 
-      & > .hst-badge__count {
+      & > .hst-badge-count {
         position: absolute;
         display: inline-flex;
         top: 0;

--- a/src/pages/ui-components/Box/index.tsx
+++ b/src/pages/ui-components/Box/index.tsx
@@ -28,7 +28,6 @@ export interface BoxProps extends Pick<BoxPropsMui, BoxPropsExtends> {
 
 const Box = (props: BoxProps) => {
   const { children, className, paper, ...rest } = props;
-
   const classes = useStyles(props);
 
   return (

--- a/src/pages/ui-components/Breadcrumb/Item/index.tsx
+++ b/src/pages/ui-components/Breadcrumb/Item/index.tsx
@@ -21,29 +21,30 @@ const BreadcrumbItem = ({ children, className, isActive }: BreadcrumbItemProps) 
   const { separator } = useBreadcrumb();
 
   return (
-    <li className={cx(className, isActive && '--active')}>
-      <span className='__content' {...(isActive && { 'aria-current': 'page' })}>
+    <li className={cx(className, isActive && 'hst-breadcrumb-item-active')}>
+      <span className='hst-breadcrumb-item-content' {...(isActive && { 'aria-current': 'page' })}>
         <LongTextToolTip>{children}</LongTextToolTip>
       </span>
-      <span role='presentation' className='__separator'>
+
+      <span role='presentation' className='hst-breadcrumb-separator'>
         {separator ?? <SeparatorIcon />}
       </span>
     </li>
   );
 };
 
-export default React.memo(styled(BreadcrumbItem, { label: 'houston-breadcrumb-item' })`
+export default React.memo(styled(BreadcrumbItem, { label: 'hst-breadcrumb-item' })`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
 
-    .__content {
+    .hst-breadcrumb-item-content {
       display: flex;
       align-items: center;
       padding: ${theme.spacing.inset.xxxs};
     }
 
-    &.--active {
+    &.hst-breadcrumb-item-active {
       font-weight: ${theme.font.weight.semibold};
     }
   `}

--- a/src/pages/ui-components/Breadcrumb/Link/index.tsx
+++ b/src/pages/ui-components/Breadcrumb/Link/index.tsx
@@ -34,23 +34,24 @@ const BreadcrumbLink = ({ as: Tag = 'a', icon, children, className, ...rest }: B
 
   return (
     <li className={className}>
-      <Tag {...rest} className='__tag'>
-        {!!icon && <span className='__icon'>{icon}</span>}
+      <Tag {...rest} className='hst-breadcrumb-link-tag'>
+        {!!icon && <span className='hst-breadcrumb-link-icon'>{icon}</span>}
         {!!children && <LongTextToolTip>{children}</LongTextToolTip>}
       </Tag>
-      <span role='presentation' className='__separator'>
+
+      <span role='presentation' className='hst-breadcrumb-separator'>
         {separator ?? <SeparatorIcon />}
       </span>
     </li>
   );
 };
 
-export default React.memo(styled(BreadcrumbLink, { label: 'houston-breadcrumb-link' })`
+export default React.memo(styled(BreadcrumbLink, { label: 'hst-breadcrumb-link' })`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
 
-    .__tag {
+    .hst-breadcrumb-link-tag {
       display: flex;
       align-items: center;
       border-radius: ${theme.border.radius.xs};
@@ -77,7 +78,7 @@ export default React.memo(styled(BreadcrumbLink, { label: 'houston-breadcrumb-li
       color: ${theme.neutralColor.low.pure};
     }
 
-    .__icon {
+    .hst-breadcrumb-link-icon {
       line-height: 0;
       color: ${theme.neutralColor.low.pure};
       max-height: ${theme.pxToRem(16)}rem;
@@ -90,7 +91,7 @@ export default React.memo(styled(BreadcrumbLink, { label: 'houston-breadcrumb-li
       }
     }
 
-    .__icon ~ .__text {
+    .hst-breadcrumb-link-icon ~ .hst-breadcrumb-text {
       margin-left: ${theme.spacing.inset.xxxs};
     }
   `}

--- a/src/pages/ui-components/Breadcrumb/index.tsx
+++ b/src/pages/ui-components/Breadcrumb/index.tsx
@@ -16,15 +16,15 @@ const Breadcrumb = ({ children, className, separator }: BreadcrumbProps) => {
   return (
     <BreadcrumbProvider separator={separator}>
       <nav aria-label='breadcrumb' className={className}>
-        <ol className='__list'>{children}</ol>
+        <ol className='hst-breadcrumb-list'>{children}</ol>
       </nav>
     </BreadcrumbProvider>
   );
 };
 
-const BreadcrumbWrapper = styled(Breadcrumb, { label: 'houston-breadcrumb' })`
+const BreadcrumbWrapper = styled(Breadcrumb, { label: 'hst-breadcrumb' })`
   ${({ theme }) => css`
-    .__list {
+    .hst-breadcrumb-list {
       display: flex;
       align-items: center;
       font-family: ${theme.font.family.base};
@@ -33,11 +33,11 @@ const BreadcrumbWrapper = styled(Breadcrumb, { label: 'houston-breadcrumb' })`
       line-height: ${theme.line.height.lg};
       color: ${theme.neutralColor.low.pure};
 
-      li:last-child .__separator {
+      li:last-child .hst-breadcrumb-separator {
         display: none;
       }
 
-      .__separator {
+      .hst-breadcrumb-separator {
         display: flex;
         align-items: center;
         margin: 0 ${theme.spacing.inset.xxxs};

--- a/src/pages/ui-components/Breadcrumb/internals/LongTextToolTip/index.tsx
+++ b/src/pages/ui-components/Breadcrumb/internals/LongTextToolTip/index.tsx
@@ -10,12 +10,12 @@ const LongTextToolTip = ({ children }: LongTextToolTip) => {
   if (typeof children === 'string' && children.length > 32) {
     return (
       <Tooltip placement='bottom' title={children}>
-        <span className='__text'>{children.slice(0, 32) + ' ...'}</span>
+        <span className='hst-breadcrumb-text'>{children.slice(0, 32) + ' ...'}</span>
       </Tooltip>
     );
   }
 
-  return <span className='__text'>{children}</span>;
+  return <span className='hst-breadcrumb-text'>{children}</span>;
 };
 
 export default React.memo(LongTextToolTip);

--- a/src/pages/ui-components/Button/index.mdx
+++ b/src/pages/ui-components/Button/index.mdx
@@ -24,13 +24,13 @@ import Button from '@eduzz/houston-ui/Button';
 
 <Playground>
   <Row>
-    <Column>
+    <Column xs='auto'>
       <Button>Contained</Button>
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Button variant='outlined'>Outlined</Button>
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Button variant='text'>Text</Button>
     </Column>
   </Row>
@@ -40,10 +40,10 @@ import Button from '@eduzz/houston-ui/Button';
 
 <Playground>
   <Row>
-    <Column>
+    <Column xs='auto'>
       <Button disabled>Disabled</Button>
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Button loading>loading</Button>
     </Column>
   </Row>
@@ -53,10 +53,10 @@ import Button from '@eduzz/houston-ui/Button';
 
 <Playground>
   <Row>
-    <Column>
+    <Column xs='auto'>
       <Button startIcon={<FaceHappyOutlineIcon />}>Start</Button>
     </Column>
-    <Column>
+    <Column xs='auto'>
       <Button variant='outlined' endIcon={<FaceHappyOutlineIcon />}>
         End
       </Button>
@@ -64,14 +64,13 @@ import Button from '@eduzz/houston-ui/Button';
   </Row>
 </Playground>
 
-| prop      | tipo                                  | obrigatório | padrão      |
-| --------- | ------------------------------------- | ----------- | ----------- |
-| disabled  | `boolean`                             | `false`     | `false`     |
-| startIcon | `React.ReactNode`                     | `false`     | -           |
-| endIcon   | `React.ReactNode`                     | `false`     | -           |
-| variant   | contained &#124; outlined &#124; text | `false`     | `contained` |
-| href      | `string`                              | `false`     | -           |
-| endIcon   | `React.ReactNode`                     | `false`     | -           |
-| fullWidth | `boolean`                             | `false`     | `false`     |
-| loading   | `boolean`                             | `false`     | `false`     |
-| onClick   | `function`                            | `false`     | -           |
+| prop      | tipo              | obrigatório | padrão      |
+| --------- | ----------------- | ----------- | ----------- |
+| disabled  | `boolean`         | `false`     | `false`     |
+| startIcon | `React.ReactNode` | `false`     | -           |
+| endIcon   | `React.ReactNode` | `false`     | -           |
+| variant   | `ButtonVariant`   | `false`     | `contained` |
+| href      | `string`          | `false`     | -           |
+| endIcon   | `React.ReactNode` | `false`     | -           |
+| fullWidth | `boolean`         | `false`     | `false`     |
+| loading   | `boolean`         | `false`     | `false`     |

--- a/src/pages/ui-components/Button/index.tsx
+++ b/src/pages/ui-components/Button/index.tsx
@@ -4,13 +4,13 @@ import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
 
 import Spinner from '../Loaders/Spinner';
 
-export type IButtonVariant = 'contained' | 'outlined' | 'text';
+export type ButtonVariant = 'contained' | 'outlined' | 'text';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     React.RefAttributes<HTMLButtonElement>,
     StyledProp {
-  variant?: IButtonVariant;
+  variant?: ButtonVariant;
   loading?: boolean;
   fullWidth?: boolean;
   startIcon?: React.ReactNode;
@@ -41,27 +41,32 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     <button
       ref={ref}
       role='button'
-      className={cx(className, 'hst-button', `--${variant ?? 'contained'}`, {
-        '--full-width': fullWidth,
-        '--disabled': disabled || loading,
-        '--active': active
+      className={cx(className, 'hst-button', `hst-button-variant-${variant ?? 'contained'}`, {
+        'hst-button-full-width': fullWidth,
+        'hst-button-disabled': disabled || loading,
+        'hst-button-active': active
       })}
       type={type}
       {...rest}
       disabled={disabled || loading}
       aria-disabled={disabled}
     >
-      {!!startIcon && <span className={cx('__startIcon', { '--hidden': loading })}>{startIcon}</span>}
-      {!loading && <span className='__text'>{children}</span>}
+      {!!startIcon && (
+        <span className={cx('hst-button-start-icon', { 'hst-button-hidden': loading })}>{startIcon}</span>
+      )}
+
+      {!loading && <span className='hst-button-text'>{children}</span>}
+
       {loading && (
         <>
-          <span className='__loader'>
+          <span className='hst-button-loader'>
             <Spinner size={20} color='inherit' />
           </span>
-          <span className='__text --hidden'>{children}</span>
+          <span className='hst-button-text hst-button-hidden'>{children}</span>
         </>
       )}
-      {!!endIcon && <span className={cx('__endIcon', { '--hidden': loading })}>{endIcon}</span>}
+
+      {!!endIcon && <span className={cx('hst-button-end-icon', { 'hst-button-hidden': loading })}>{endIcon}</span>}
     </button>
   )
 );
@@ -70,7 +75,7 @@ const HEIGHT = 48;
 const MIN_WIDTH = 96;
 const ICON_SIZE = 24;
 
-export default styled(Button, { label: 'houston-button' })(({ theme }) => {
+export default styled(Button, { label: 'hst-button' })(({ theme }) => {
   return css`
     border: none;
     cursor: pointer;
@@ -93,22 +98,22 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
     }
 
     :focus,
-    .--active {
+    .hst-button-active {
       outline: solid ${theme.border.width.sm} ${theme.feedbackColor.informative.pure};
     }
 
-    &.--contained {
+    &.hst-button-variant-contained {
       background-color: ${theme.brandColor.primary.pure};
       color: ${theme.neutralColor.high.pure};
 
       &:hover:not(:disabled),
       &:focus,
-      &.--active {
+      &.hst-button-active {
         background-color: ${theme.hexToRgba(theme.brandColor.primary.pure, theme.opacity.level[8])};
       }
     }
 
-    &.--outlined {
+    &.hst-button-variant-outlined {
       background-color: transparent;
       border: ${theme.border.width.xs} solid;
       border-color: ${theme.neutralColor.low.pure};
@@ -116,60 +121,59 @@ export default styled(Button, { label: 'houston-button' })(({ theme }) => {
 
       &:hover:not(:disabled),
       &:focus,
-      &.--active {
+      &.hst-button-active {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       }
     }
 
-    &.--text {
+    &.hst-button-variant-text {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
       color: ${theme.neutralColor.low.pure};
 
       &:hover:not(:disabled),
       &:focus,
-      &.--active {
+      &.hst-button-active {
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       }
     }
 
-    &.--disabled {
+    &.hst-button-disabled {
       border: none;
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
       cursor: not-allowed;
     }
 
-    &.--full-width {
+    &.hst-button-full-width {
       width: 100%;
     }
 
-    & > .__loader {
+    & > .hst-button-loader {
       position: absolute;
       left: 50%;
       transform: translate(-50%, 0);
     }
 
-    & > .--hidden {
+    & > .hst-button-hidden {
       visibility: hidden;
     }
 
-    & > .__startIcon {
+    & > .hst-button-start-icon {
       margin-right: ${theme.spacing.inline.nano};
     }
 
-    & > .__endIcon {
+    & > .hst-button-end-icon {
       margin-left: ${theme.spacing.inline.nano};
     }
 
-    & > .__startIcon,
-    & > .__endIcon {
+    & > .hst-button-start-icon,
+    & > .hst-button-end-icon {
       line-height: 0;
-    }
 
-    & > .__startIcon > svg,
-    & > .__endIcon > svg {
-      vertical-align: middle;
-      font-size: ${theme.pxToRem(ICON_SIZE)}rem;
+      svg {
+        vertical-align: middle;
+        font-size: ${theme.pxToRem(ICON_SIZE)}rem;
+      }
     }
   `;
 });

--- a/src/pages/ui-components/ButtonIcon/index.tsx
+++ b/src/pages/ui-components/ButtonIcon/index.tsx
@@ -3,7 +3,7 @@ import IconButton, { IconButtonProps } from '../IconButton';
 export interface ButtonIcon extends IconButtonProps {}
 
 /**
- * @deprecated Migrar para IconButton
+ * @deprecated Migrate to IconButton
  */
 const ButtonIcon = (props: ButtonIcon) => {
   return <IconButton {...props} />;

--- a/src/pages/ui-components/Card/index.mdx
+++ b/src/pages/ui-components/Card/index.mdx
@@ -27,7 +27,7 @@ import Card from '@eduzz/houston-ui/Card';
     <Grid.Column>
       <Card>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston
@@ -43,7 +43,7 @@ import Card from '@eduzz/houston-ui/Card';
     <Grid.Column>
       <Card>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston
@@ -59,7 +59,7 @@ import Card from '@eduzz/houston-ui/Card';
     <Grid.Column>
       <Card>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston
@@ -75,7 +75,7 @@ import Card from '@eduzz/houston-ui/Card';
   </Grid.Row>
 </Playground>
 
-### Espaçamento
+### Espaçamento interno
 
 Você pode alterar o espaçamento interno conforme sua necessidade.
 
@@ -89,7 +89,7 @@ Você pode alterar o espaçamento interno conforme sua necessidade.
             <Grid.Column>
               <Card padding={s}>
                 <Box xs={{ margin: '0 0 1rem 0' }}>
-                  <img src='/houston/img/welcome.png' width='100%' />
+                  <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
                 </Box>
                 <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
                   Padding {s}
@@ -105,7 +105,7 @@ Você pode alterar o espaçamento interno conforme sua necessidade.
             <Grid.Column>
               <Card padding={s}>
                 <Box xs={{ margin: '0 0 1rem 0' }}>
-                  <img src='/houston/img/welcome.png' width='100%' />
+                  <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
                 </Box>
                 <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
                   Padding {s}
@@ -121,7 +121,7 @@ Você pode alterar o espaçamento interno conforme sua necessidade.
             <Grid.Column>
               <Card padding={s}>
                 <Box xs={{ margin: '0 0 1rem 0' }}>
-                  <img src='/houston/img/welcome.png' width='100%' />
+                  <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
                 </Box>
                 <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
                   Padding {s}
@@ -150,7 +150,7 @@ Quando passado a prop `onClick` para o componente, ele ativa alguns comportament
     <Grid.Column>
       <Card onClick={() => alert('Houston Design System')}>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston
@@ -166,7 +166,7 @@ Quando passado a prop `onClick` para o componente, ele ativa alguns comportament
     <Grid.Column>
       <Card disabled onClick={() => console.log('Houston Design System')}>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston
@@ -182,7 +182,7 @@ Quando passado a prop `onClick` para o componente, ele ativa alguns comportament
     <Grid.Column>
       <Card onClick={() => console.log('Houston Design System')}>
         <Box xs={{ margin: '0 0 1rem 0' }}>
-          <img src='/houston/img/welcome.png' width='100%' />
+          <img src='/houston/img/welcome.png' width='100%' alt='Preview' />
         </Box>
         <Typography.Heading as='h3' weight='bold' size='sm' marginBottom>
           Houston

--- a/src/pages/ui-components/Card/index.tsx
+++ b/src/pages/ui-components/Card/index.tsx
@@ -29,9 +29,9 @@ const Card = ({
       {...(clickable && { tabIndex: 0, role: 'button', onClick })}
       className={cx(
         className,
-        `--hst-padding-${padding}`,
-        { '--hst-clickable': !disabled && clickable },
-        { '--hst-disabled': disabled }
+        `hst-card-padding-${padding}`,
+        { 'hst-card-clickable': !disabled && clickable },
+        { 'hst-card-disabled': disabled }
       )}
       {...rest}
     >
@@ -60,9 +60,9 @@ export default styled(Card, { label: 'hst-card' })`
       giant: theme.spacing.giant
     };
 
-    Object.entries(availableSpacing).forEach(([key, value]) =>
+    Object.entries(availableSpacing).forEach(([spacing, value]) =>
       modifiers.push(css`
-        &.--hst-padding-${key} {
+        &.hst-card-padding-${spacing} {
           padding: ${value};
         }
       `)
@@ -75,13 +75,13 @@ export default styled(Card, { label: 'hst-card' })`
 
       ${modifiers}
 
-      &.--hst-disabled {
+      &.hst-card-disabled {
         cursor: not-allowed;
         pointer-events: none;
         opacity: ${theme.opacity.level[6]};
       }
 
-      &.--hst-clickable {
+      &.hst-card-clickable {
         transition: 0.3s;
         cursor: pointer;
 

--- a/src/pages/ui-components/Dialog/Content/index.tsx
+++ b/src/pages/ui-components/Dialog/Content/index.tsx
@@ -9,7 +9,7 @@ const DialogContent = ({
   ...rest
 }: DialogContentProps & React.HTMLAttributes<HTMLDivElement> & StyledProp) => <div {...rest}>{children}</div>;
 
-export default styled(DialogContent, { label: 'houston-dialog-content' })`
+export default styled(DialogContent, { label: 'hst-dialog-content' })`
   ${({ theme }) => css`
     padding: ${theme.spacing.inset.sm};
     overflow: auto;

--- a/src/pages/ui-components/Dialog/Dialog.tsx
+++ b/src/pages/ui-components/Dialog/Dialog.tsx
@@ -44,10 +44,14 @@ const Dialog = ({
   }
 
   return (
-    <Portal target='houston-dialog'>
+    <Portal target='hst-dialog'>
       <Overlay visible={visible}>
         <DialogContextProvider value={contextValue}>
-          <ModalBase className={cx(className, `--dialog-size-${size}`, `--dialog-type-${type}`)} aria-modal {...rest}>
+          <ModalBase
+            className={cx(className, `hst-dialog-size-${size}`, `hst-dialog-type-${type}`)}
+            aria-modal
+            {...rest}
+          >
             {children}
           </ModalBase>
         </DialogContextProvider>
@@ -56,14 +60,14 @@ const Dialog = ({
   );
 };
 
-const DialogWrapper = styled(Dialog, { label: 'houston-dialog' })`
+const DialogWrapper = styled(Dialog, { label: 'hst-dialog' })`
   ${({ theme }) => {
     const modifiersSizes: CSSInterpolation[] = [];
     const modifiersTypes: CSSInterpolation[] = [];
 
     Object.entries(modalSizesInPx).forEach(([size, value]) =>
       modifiersSizes.push(css`
-        &.--dialog-size-${size} {
+        &.hst-dialog-size-${size} {
           width: ${theme.pxToRem(value)}rem;
         }
       `)
@@ -71,9 +75,9 @@ const DialogWrapper = styled(Dialog, { label: 'houston-dialog' })`
 
     Object.keys(theme.feedbackColor).forEach(color =>
       modifiersTypes.push(css`
-        &.--dialog-type-${color} {
-          .dialog-header__wrapper {
-            .dialog-header__icon {
+        &.hst-dialog-type-${color} {
+          .hst-dialog-header-wrapper {
+            .hst-dialog-header-icon {
               svg {
                 fill: ${theme.feedbackColor[color].pure};
               }
@@ -104,7 +108,6 @@ export default nestedComponent(React.memo(DialogWrapper), {
   Header,
   Content,
   Footer,
-  // Evita referência circular, pois o Global depende do Dialog
   alert: (params: Parameters<typeof showAlert>[0]) => showAlert(params),
   confirm: (params: Parameters<typeof showConfirm>[0]) => showConfirm(params)
 });

--- a/src/pages/ui-components/Dialog/Footer/index.tsx
+++ b/src/pages/ui-components/Dialog/Footer/index.tsx
@@ -10,7 +10,7 @@ const DialogFooter = ({ children, ...rest }: DialogFooterProps & React.HTMLAttri
   return (
     <footer {...rest}>
       <Divider />
-      <div className='dialog-footer__wrapper'>{children}</div>
+      <div className='hst-dialog-footer-wrapper'>{children}</div>
     </footer>
   );
 };
@@ -19,7 +19,7 @@ export default styled(DialogFooter, { label: 'hst-dialog-footer' })`
   ${({ theme }) => css`
     border-radius: 0 0 ${theme.border.radius.sm} ${theme.border.radius.sm};
 
-    .dialog-footer__wrapper {
+    .hst-dialog-footer-wrapper {
       padding: ${theme.spacing.squish.xs};
       display: flex;
       align-items: center;

--- a/src/pages/ui-components/Dialog/Header/index.tsx
+++ b/src/pages/ui-components/Dialog/Header/index.tsx
@@ -34,14 +34,14 @@ const DialogHeader = ({
 
   return (
     <header {...rest}>
-      <div className='dialog-header__wrapper'>
+      <div className='hst-dialog-header-wrapper'>
         {showTypeIcon && (
-          <span role='img' className='dialog-header__icon'>
+          <span role='img' className='hst-dialog-header-icon'>
             {IconMap[type]}
           </span>
         )}
 
-        <span className='dialog-header__title'>
+        <span className='dialog-header-title'>
           {!disableTypography ? (
             <Typography as='h6' size='sm'>
               {children}
@@ -57,14 +57,14 @@ const DialogHeader = ({
   );
 };
 
-export default React.memo(styled(DialogHeader, { label: 'houston-dialog-header' })`
+export default React.memo(styled(DialogHeader, { label: 'hst-dialog-header' })`
   ${({ theme }) => css`
     flex-grow: 0;
     flex-shrink: 1;
     flex-basis: 0%;
     border-radius: ${theme.border.radius.sm} ${theme.border.radius.sm} 0 0;
 
-    .dialog-header__wrapper {
+    .hst-dialog-header-wrapper {
       padding: ${theme.spacing.inset.sm};
       display: flex;
       align-items: center;
@@ -73,7 +73,7 @@ export default React.memo(styled(DialogHeader, { label: 'houston-dialog-header' 
         padding: ${theme.spacing.inset.xs};
       }
 
-      .dialog-header__icon {
+      .hst-dialog-header-icon {
         line-height: 0;
         margin-right: ${theme.spacing.inline.nano};
       }

--- a/src/pages/ui-components/Divider/index.mdx
+++ b/src/pages/ui-components/Divider/index.mdx
@@ -37,6 +37,10 @@ import Divider from '@eduzz/houston-ui/Divider';
   <Box margin='8px 0 8px'>
     <Divider />
   </Box>
+  <Typography>
+    Excepturi iusto consequuntur molestias, eligendi perspiciatis commodi error vero tempora voluptatum accusamus
+    similique molestiae iste reiciendis animi, nisi mollitia debitis repudiandae soluta.
+  </Typography>
 </Playground>
 
 ### Vertical

--- a/src/pages/ui-components/Divider/index.tsx
+++ b/src/pages/ui-components/Divider/index.tsx
@@ -15,21 +15,19 @@ const Divider = ({ className, vertical }: Divider) => {
     }
   }, [vertical]);
 
-  return <hr ref={ref} className={cx(className, `--${vertical ? 'vertical' : 'horizontal'}`)} />;
+  return <hr ref={ref} className={cx(className, { 'hst-divider-vertical': vertical })} />;
 };
 
-export default React.memo(styled(Divider, { label: 'houston-divider' })`
+export default React.memo(styled(Divider, { label: 'hst-divider' })`
   ${({ theme }) => css`
     border-style: solid;
     opacity: ${theme.opacity.level[3]};
     border-color: ${theme.neutralColor.low.pure};
+    border-width: 0 0 ${theme.border.width.xs};
+    width: 100%;
 
-    &.--horizontal {
-      width: 100%;
-      border-width: 0 0 ${theme.border.width.xs};
-    }
-
-    &.--vertical {
+    &.hst-divider-vertical {
+      width: auto;
       border-width: 0 0 0 ${theme.border.width.xs};
       display: inline-flex;
     }

--- a/src/pages/ui-components/Drawer/Drawer.tsx
+++ b/src/pages/ui-components/Drawer/Drawer.tsx
@@ -52,7 +52,7 @@ const Drawer = ({
             role='dialog'
             tabIndex={-1}
             aria-modal
-            className={cx(className, `--hst-drawer-size-${size}`, `--hst-drawer-placement-${placement}`)}
+            className={cx(className, `hst-drawer-size-${size}`, `hst-drawer-placement-${placement}`)}
             {...rest}
           >
             {children}
@@ -70,7 +70,7 @@ const DrawerWrapper = styled(Drawer, { label: 'hst-drawer' })`
 
     Object.entries(modalSizesInPx).forEach(([size, value]) =>
       modifiers.push(css`
-        &.--hst-drawer-size-${size} {
+        &.hst-drawer-size-${size} {
           width: ${theme.pxToRem(value)}rem;
         }
       `)
@@ -78,7 +78,7 @@ const DrawerWrapper = styled(Drawer, { label: 'hst-drawer' })`
 
     placementMap.forEach(placement =>
       modifiers.push(css`
-        &.--hst-drawer-placement-${placement} {
+        &.hst-drawer-placement-${placement} {
           ${placement}: 0%;
         }
       `)

--- a/src/pages/ui-components/Drawer/Footer/index.tsx
+++ b/src/pages/ui-components/Drawer/Footer/index.tsx
@@ -10,14 +10,14 @@ const DrawerFooter = ({ children, ...rest }: DrawerFooterProps & React.HTMLAttri
   return (
     <footer {...rest}>
       <Divider />
-      <div className='hst-drawer-footer__wrapper'>{children}</div>
+      <div className='hst-drawer-footer-wrapper'>{children}</div>
     </footer>
   );
 };
 
 export default styled(DrawerFooter, { label: 'hst-drawer-footer' })`
   ${({ theme }) => css`
-    .hst-drawer-footer__wrapper {
+    .hst-drawer-footer-wrapper {
       padding: ${theme.spacing.squish.xs};
       display: flex;
       align-items: center;

--- a/src/pages/ui-components/Drawer/Header/index.tsx
+++ b/src/pages/ui-components/Drawer/Header/index.tsx
@@ -25,8 +25,8 @@ const DrawerHeader = ({
 
   return (
     <header {...rest}>
-      <div className='hst-drawer-header__wrapper'>
-        <span className='hst-drawer-header__title'>
+      <div className='hst-drawer-header-wrapper'>
+        <span className='hst-drawer-header-title'>
           {!disableTypography ? (
             <Typography as='h6' size='sm'>
               {children}
@@ -37,7 +37,7 @@ const DrawerHeader = ({
         </span>
 
         {closeIcon && (
-          <IconButton className='hst-drawer-header__close' aria-label='Fechar Drawer' size='md' onClick={onClose}>
+          <IconButton className='hst-drawer-header-close' aria-label='Fechar Drawer' size='md' onClick={onClose}>
             <IconClose />
           </IconButton>
         )}
@@ -54,7 +54,7 @@ export default React.memo(styled(DrawerHeader, { label: 'hst-drawer-header' })`
     flex-shrink: 1;
     flex-basis: 0%;
 
-    .hst-drawer-header__wrapper {
+    .hst-drawer-header-wrapper {
       padding: ${theme.spacing.inset.sm};
       display: flex;
       align-items: center;
@@ -64,7 +64,7 @@ export default React.memo(styled(DrawerHeader, { label: 'hst-drawer-header' })`
         padding: ${theme.spacing.inset.xs};
       }
 
-      .hst-drawer-header__close {
+      .hst-drawer-header-close {
         margin-left: ${theme.spacing.inline.xxs};
       }
     }

--- a/src/pages/ui-components/Dropdown/index.tsx
+++ b/src/pages/ui-components/Dropdown/index.tsx
@@ -132,10 +132,10 @@ const DropdownWrapper = styled(Dropdown)`
         background: ${theme.neutralColor.high.pure};
       }
 
-      &.popover[data-popper-placement='top'],
-      &.popover[data-popper-placement='top-start'],
-      &.popover[data-popper-placement='top-end'] {
-        & > .__container {
+      &.hst-popover[data-popper-placement='top'],
+      &.hst-popover[data-popper-placement='top-start'],
+      &.hst-popover[data-popper-placement='top-end'] {
+        & > .hst-popover-container {
           margin-bottom: ${ARROW_HALF_SIZE_IN_REM};
         }
 
@@ -148,10 +148,10 @@ const DropdownWrapper = styled(Dropdown)`
         }
       }
 
-      &.popover[data-popper-placement='bottom'],
-      &.popover[data-popper-placement='bottom-start'],
-      &.popover[data-popper-placement='bottom-end'] {
-        & > .__container {
+      &.hst-popover[data-popper-placement='bottom'],
+      &.hst-popover[data-popper-placement='bottom-start'],
+      &.hst-popover[data-popper-placement='bottom-end'] {
+        & > .hst-popover-container {
           margin-top: ${ARROW_HALF_SIZE_IN_REM};
         }
 
@@ -165,10 +165,10 @@ const DropdownWrapper = styled(Dropdown)`
         }
       }
 
-      &.popover[data-popper-placement='left'],
-      &.popover[data-popper-placement='left-start'],
-      &.popover[data-popper-placement='left-end'] {
-        & > .__container {
+      &.hst-popover[data-popper-placement='left'],
+      &.hst-popover[data-popper-placement='left-start'],
+      &.hst-popover[data-popper-placement='left-end'] {
+        & > .hst-popover-container {
           position: relative;
           left: -${ARROW_HALF_SIZE_IN_REM};
         }
@@ -183,10 +183,10 @@ const DropdownWrapper = styled(Dropdown)`
         }
       }
 
-      &.popover[data-popper-placement='right'],
-      &.popover[data-popper-placement='right-start'],
-      &.popover[data-popper-placement='right-end'] {
-        & > .__container {
+      &.hst-popover[data-popper-placement='right'],
+      &.hst-popover[data-popper-placement='right-start'],
+      &.hst-popover[data-popper-placement='right-end'] {
+        & > .hst-popover-container {
           position: relative;
           right: -${ARROW_HALF_SIZE_IN_REM};
         }

--- a/src/pages/ui-components/Forms/Checkbox/index.tsx
+++ b/src/pages/ui-components/Forms/Checkbox/index.tsx
@@ -69,10 +69,10 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxRadioProps>(
     return (
       <label
         className={cx(className, {
-          '--hst-empty': !label,
-          '--hst-checked': isChecked,
-          '--hst-error': hasError,
-          '--hst-disabled': disabled
+          'hst-checkbox-empty': !label,
+          'hst-checkbox-checked': isChecked,
+          'hst-checkbox-error': hasError,
+          'hst-checkbox-disabled': disabled
         })}
         htmlFor={props.id}
       >
@@ -101,12 +101,12 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxRadioProps>(
   }
 );
 
-const StyledCheckbox = styled(withForm(React.memo(Checkbox)), { label: 'hst-checkbox' })(
+const CheckboxWrapper = styled(withForm(React.memo(Checkbox)), { label: 'hst-checkbox' })(
   ({ theme }) => css`
     display: flex;
     cursor: pointer;
 
-    &.--hst-empty {
+    &.hst-checkbox-empty {
       display: inline-block;
       margin: 0;
     }
@@ -165,7 +165,7 @@ const StyledCheckbox = styled(withForm(React.memo(Checkbox)), { label: 'hst-chec
       border-radius: ${theme.border.radius.xs};
     }
 
-    &.--hst-checked > .hst-checkbox-icon-container {
+    &.hst-checkbox-checked > .hst-checkbox-icon-container {
       color: white;
       background-color: ${theme.brandColor.primary.pure};
       border-color: ${theme.brandColor.primary.pure};
@@ -176,23 +176,23 @@ const StyledCheckbox = styled(withForm(React.memo(Checkbox)), { label: 'hst-chec
       }
     }
 
-    &.--hst-error:not(.--hst-checked) > .hst-checkbox-icon-container {
+    &.hst-checkbox-error:not(.hst-checkbox-checked) > .hst-checkbox-icon-container {
       background-color: ${theme.hexToRgba(theme.feedbackColor.negative.pure, theme.opacity.level[2])};
       border-color: ${theme.feedbackColor.negative.pure};
     }
 
-    &.--hst-error.--hst-checked > .hst-checkbox-icon-container {
+    &.hst-checkbox-error.hst-checkbox-checked > .hst-checkbox-icon-container {
       background-color: ${theme.feedbackColor.negative.pure};
       border-color: ${theme.feedbackColor.negative.pure};
     }
 
-    &.--hst-disabled {
+    &.hst-checkbox-disabled {
       cursor: not-allowed;
       opacity: ${theme.opacity.level[6]};
     }
   `
 );
 
-export default nestedComponent(StyledCheckbox, {
+export default nestedComponent(CheckboxWrapper, {
   Group
 });

--- a/src/pages/ui-components/Forms/Color/index.mdx
+++ b/src/pages/ui-components/Forms/Color/index.mdx
@@ -31,17 +31,6 @@ import Color from '@eduzz/houston-ui/Forms/Color';
   }}
 </Playground>
 
-| prop           | tipo              | obrigatório | padrão  | descrição                                                                           |
-| -------------- | ----------------- | ----------- | ------- | ----------------------------------------------------------------------------------- |
-| name           | `string`          | `true`      | -       | -                                                                                   |
-| label          | `string`          | `false`     | -       | -                                                                                   |
-| placeholder    | `string`          | `false`     | -       | -                                                                                   |
-| disabled       | `boolean`         | `false`     | `false` | -                                                                                   |
-| fullWidth      | `boolean`         | `false`     | `true`  | -                                                                                   |
-| loading        | `boolean`         | `false`     | -       | Exibe ícone de carregamento no componente de texto.                                 |
-| helperText     | `string`          | `false`     | -       | Exibe texto de ajuda abaixo do componente de texto.                                 |
-| errorMessage   | `string`          | `false`     | -       | Exibe uma mensagem de erro no componente de texto, assim como indica erro no campo. |
-| value          | `string`          | `false`     | -       | -                                                                                   |
-| onChange       | `function`        | `false`     | -       | Função disparada ao alterar o valor do campo de texto.                              |
-| endAdornment   | `React.ReactNode` | `false`     | -       | Ícone ou botão com ícone que será exibido no final do campo.                        |
-| startAdornment | `React.ReactNode` | `false`     | -       | Ícone ou botão com ícone que será exibido no início do campo.                       |
+### Props
+
+Equivalente as props do componente [Input](/houston/ui-components/Forms/Input).

--- a/src/pages/ui-components/Forms/Color/index.tsx
+++ b/src/pages/ui-components/Forms/Color/index.tsx
@@ -33,7 +33,7 @@ const Color = ({ className, value, errorMessage, disabled, loading, onChange, ..
         {...props}
         value={value}
         ref={popoverTargetProps.ref}
-        disabled={disabled}
+        disabled={disabled || loading}
         loading={loading}
         errorMessage={errorMessage}
         onChange={handleChange}

--- a/src/pages/ui-components/Forms/Currency/index.mdx
+++ b/src/pages/ui-components/Forms/Currency/index.mdx
@@ -25,22 +25,6 @@ import CurrencyField from '@eduzz/houston-ui/Forms/Currency';
   }}
 </Playground>
 
-| prop           | tipo                        | obrigatório | padrão  | descrição                                                                           |
-| -------------- | --------------------------- | ----------- | ------- | ----------------------------------------------------------------------------------- |
-| label          | `React.ReactNode`           | `false`     | -       | -                                                                                   |
-| type           | `React.InputHTMLAttributes` | `false`     | `text`  | -                                                                                   |
-| placeholder    | `string`                    | `false`     | -       | -                                                                                   |
-| disabled       | `boolean`                   | `false`     | `false` | -                                                                                   |
-| fullWidth      | `boolean`                   | `false`     | `true`  | -                                                                                   |
-| className      | `string`                    | `false`     | -       | -                                                                                   |
-| loading        | `boolean`                   | `false`     | -       | Exibe ícone de carregamento no componente de texto.                                 |
-| helperText     | `string`                    | `false`     | -       | Exibe texto de ajuda abaixo do componente de texto.                                 |
-| errorMessage   | `string`                    | `false`     | -       | Exibe uma mensagem de erro no componente de texto, assim como indica erro no campo. |
-| form           | `IFormAdapter`              | `false`     | -       | -                                                                                   |
-| value          | `any`                       | `false`     | -       | -                                                                                   |
-| margin         | `none`, `dense`, `normal`   | `normal`    | -       | -                                                                                   |
-| onChange       | `function`                  | `false`     | -       | Função disparada ao alterar o valor do campo de texto.                              |
-| onPressEnter   | `function`                  | `false`     | -       | Função disparada ao apertar Enter dentro do campo de texto.                         |
-| endAdornment   | `React.ReactNode`           | `false`     | -       | Ícone ou botão com ícone que será exibido no final do campo.                        |
-| startAdornment | `React.ReactNode`           | `false`     | -       | Ícone ou botão com ícone que será exibido no início do campo.                       |
-| required       | `boolean`                   | `false`     | -       | -                                                                                   |
+### Props
+
+Equivalente as props do componente [Input](/houston/ui-components/Forms/Input).

--- a/src/pages/ui-components/Forms/DatePicker/index.tsx
+++ b/src/pages/ui-components/Forms/DatePicker/index.tsx
@@ -123,8 +123,8 @@ const DatePicker = ({
       locale={locale}
       value={value}
       defaultPickerValue={new Date()}
-      className={cx(className, { '--hst-datepicker-full-width': fullWidth })}
-      dropdownClassName={cx(className, { '--hst-datepicker-enable-seconds': enableSeconds })}
+      className={cx(className, { 'hst-datepicker-full-width': fullWidth })}
+      dropdownClassName={cx(className, { 'hst-datepicker-enable-seconds': enableSeconds })}
       format={displayFormat ?? defaultFormats[`${mode}${enableSeconds ? 'Seconds' : ''}`]}
       inputRender={inputRender}
       onChange={onChange}
@@ -145,13 +145,13 @@ const SIZE_BUTTON = `${pxToRem(48)}rem`;
 const HOUR_WIDTH_BUTTON = `${pxToRem(63)}rem`;
 
 export default withForm(
-  styled(React.memo(DatePicker), { label: 'houston-datepicker' })(
+  styled(React.memo(DatePicker), { label: 'hst-datepicker' })(
     ({ theme }) => css`
       &.rc-picker-focused {
         border: none;
       }
 
-      &.--hst-datepicker-full-width {
+      &.hst-datepicker-full-width {
         width: 100%;
       }
 
@@ -481,7 +481,7 @@ export default withForm(
           }
         }
 
-        &.--hst-datepicker-enable-seconds .rc-picker-time-panel .rc-picker-content {
+        &.hst-datepicker-enable-seconds .rc-picker-time-panel .rc-picker-content {
           grid-template-columns: repeat(3, ${HOUR_WIDTH_BUTTON});
 
           &::before {

--- a/src/pages/ui-components/Forms/ErrorMessage/index.tsx
+++ b/src/pages/ui-components/Forms/ErrorMessage/index.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { ErrorMessage as ErrorMessageHook } from '@hookform/error-message';
 import { useFormState } from 'react-hook-form';
 
+import { cx } from '@eduzz/houston-styles';
+
 import Typography from '../../Typography';
 
 export interface ErrorMessageProps {
@@ -17,7 +19,7 @@ const ErrorMessage = ({ name, className }: ErrorMessageProps) => {
     <ErrorMessageHook
       errors={formState.errors}
       name={name}
-      render={({ message }) => <Typography className={className}>{message}</Typography>}
+      render={({ message }) => <Typography className={cx(className, 'hst-form-error-message')}>{message}</Typography>}
     />
   );
 };

--- a/src/pages/ui-components/Forms/File/DragAndDrop/UploadList/index.tsx
+++ b/src/pages/ui-components/Forms/File/DragAndDrop/UploadList/index.tsx
@@ -32,8 +32,8 @@ const UploadList = ({ className, items, onRemove }: UploadListProps) => {
             {(item.status === 'success' || item.status === 'error') && (
               <span
                 className={cx('hst-drag-and-drop-file-item-status', {
-                  '--hst-drag-and-drop-file-item-status-success': item.status === 'success',
-                  '--hst-drag-and-drop-file-item-status-error': item.status === 'error'
+                  'hst-drag-and-drop-file-item-status-success': item.status === 'success',
+                  'hst-drag-and-drop-file-item-status-error': item.status === 'error'
                 })}
               >
                 {getStatusMessage(item)}
@@ -89,11 +89,11 @@ export default styled(UploadList, { label: 'hst-drag-and-drop-file-list' })`
           font-family: ${theme.font.family.base};
           line-height: ${theme.line.height.md};
 
-          &.--hst-drag-and-drop-file-item-status-success {
+          &.hst-drag-and-drop-file-item-status-success {
             color: ${theme.feedbackColor.positive.medium};
           }
 
-          &.--hst-drag-and-drop-file-item-status-error {
+          &.hst-drag-and-drop-file-item-status-error {
             color: ${theme.feedbackColor.negative.medium};
           }
         }

--- a/src/pages/ui-components/Forms/File/DragAndDrop/index.tsx
+++ b/src/pages/ui-components/Forms/File/DragAndDrop/index.tsx
@@ -271,8 +271,8 @@ const DragAndDrop = React.forwardRef<unknown, DragAndDropProps>(
     return (
       <div
         className={cx(className, {
-          '--hst-drag-and-drop-disabled': disabled,
-          '--hst-drag-and-drop-full-width': fullWidth
+          'hst-drag-and-drop-disabled': disabled,
+          'hst-drag-and-drop-full-width': fullWidth
         })}
       >
         <span className='hst-drag-and-drop-label'>{label}</span>
@@ -312,11 +312,11 @@ const StyledDragAndDrop = styled(withForm(DragAndDrop), { label: 'hst-drag-and-d
     min-width: ${theme.pxToRem(320)}rem;
     flex: 1;
 
-    &.--hst-drag-and-drop-full-width {
+    &.hst-drag-and-drop-full-width {
       width: 100%;
     }
 
-    &.--hst-drag-and-drop-disabled {
+    &.hst-drag-and-drop-disabled {
       opacity: ${theme.opacity.level[6]};
       cursor: not-allowed;
       user-select: none;

--- a/src/pages/ui-components/Forms/Input/index.tsx
+++ b/src/pages/ui-components/Forms/Input/index.tsx
@@ -116,13 +116,16 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         disabled={disabled}
         hidden={type === 'hidden'}
         className={cx(className, {
-          '--multiline': multiline,
-          [`--multiline-rows-${rows ?? 4}`]: multiline,
-          '--disable-auto-resize': disableAutoResize
+          'hst-input-multiline': multiline,
+          [`hst-input-multiline-rows-${rows ?? 4}`]: multiline,
+          'hst-input-disable-auto-resize': disableAutoResize
         })}
       >
-        <div className='__wrapperAutoSizer'>
-          {!!multiline && !disableAutoResize && <div className='__autoSizer __text'>{value + ' '}</div>}
+        <div className='hst-input-wrapper-auto-sizer'>
+          {!!multiline && !disableAutoResize && (
+            <div className='hst-input-auto-sizer hst-input-text'>{value + ' '}</div>
+          )}
+
           {React.createElement(multiline ? 'textarea' : 'input', {
             ref,
             value: maskedValue ?? '',
@@ -130,7 +133,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             name,
             disabled,
             type,
-            className: '__input __text',
+            className: 'hst-input-input hst-input-text',
             readOnly: readOnly ?? loading,
             onChange: handleChange,
             onFocus: handleFocus,
@@ -143,15 +146,15 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   }
 );
 
-export default styled(withForm(React.memo(Input)), { label: 'houston-form-text' })(
+export default styled(withForm(React.memo(Input)), { label: 'hst-input' })(
   ({ theme }) => css`
-    & .__wrapperAutoSizer {
+    & .hst-input-wrapper-auto-sizer {
       display: grid;
       grid-template-columns: 100%;
       width: 100%;
       min-height: 100%;
 
-      & .__autoSizer {
+      & .hst-input-auto-sizer {
         pointer-events: none;
         white-space: pre-wrap;
         word-wrap: break-word;
@@ -160,7 +163,7 @@ export default styled(withForm(React.memo(Input)), { label: 'houston-form-text' 
         grid-area: 1 / 1 / 2 / 2;
       }
 
-      & .__input {
+      & .hst-input-input {
         grid-area: 1 / 1 / 2 / 2;
         height: 100%;
         width: 100%;
@@ -176,53 +179,53 @@ export default styled(withForm(React.memo(Input)), { label: 'houston-form-text' 
       }
     }
 
-    &.--multiline {
-      & .__container {
+    &.hst-input-multiline {
+      & .hst-fieldset-container {
         align-items: flex-start;
         height: auto;
 
-        & .__startAdornment,
-        & .__endAdornment {
+        & .hst-fieldset-start-adornment,
+        & .hst-fieldset-end-adornment {
           align-items: flex-start;
           margin-top: ${theme.spacing.xxxs};
         }
 
-        & .__input {
+        & .hst-input-input {
           resize: none;
           overflow: hidden;
         }
 
-        & .__autoSizer,
-        & .__input {
+        & .hst-fieldset-auto-sizer,
+        & .hst-input-input {
           padding: ${theme.spacing.xxxs};
         }
       }
 
-      &.--disable-auto-resize {
-        & .__input {
+      &.hst-input-disable-auto-resize {
+        & .hst-input-input {
           overflow: auto;
         }
       }
 
       ${ROWS.map(
         n => css`
-          &.--multiline-rows-${n} .__wrapperAutoSizer {
+          &.hst-input-multiline-rows-${n} .hst-input-wrapper-auto-sizer {
             min-height: calc(${n * 19}px + ${theme.spacing.xs});
           }
         `
       )}
     }
 
-    &.--disabled {
-      & .__label,
-      & .__input {
+    &.hst-input-disabled {
+      & .hst-input-label,
+      & .hst-input-input {
         cursor: not-allowed;
       }
     }
 
-    &.--loading {
-      & .__label,
-      & .__input {
+    &.hst-input-loading {
+      & .hst-input-label,
+      & .hst-input-input {
         cursor: progress;
       }
     }

--- a/src/pages/ui-components/Forms/Password/index.mdx
+++ b/src/pages/ui-components/Forms/Password/index.mdx
@@ -41,20 +41,4 @@ import PasswordInput from '@eduzz/houston-ui/Forms/Password';
 
 ### Props
 
-| prop           | tipo              | obrigatório | padrão  | descrição                                                                           |
-| -------------- | ----------------- | ----------- | ------- | ----------------------------------------------------------------------------------- |
-| id             | `string`          | `false`     | -       | -                                                                                   |
-| name           | `string`          | `true`      | -       | -                                                                                   |
-| label          | `string`          | `false`     | -       | -                                                                                   |
-| placeholder    | `string`          | `false`     | -       | -                                                                                   |
-| disabled       | `boolean`         | `false`     | `false` | -                                                                                   |
-| fullWidth      | `boolean`         | `false`     | `true`  | -                                                                                   |
-| className      | `string`          | `false`     | -       | -                                                                                   |
-| loading        | `boolean`         | `false`     | -       | Exibe ícone de carregamento no componente de texto.                                 |
-| helperText     | `string`          | `false`     | -       | Exibe texto de ajuda abaixo do componente de texto.                                 |
-| errorMessage   | `string`          | `false`     | -       | Exibe uma mensagem de erro no componente de texto, assim como indica erro no campo. |
-| mask           | `IFormMask`       | `false`     | -       | Máscara que será aplicada no campo.                                                 |
-| value          | `any`             | `false`     | -       | -                                                                                   |
-| onChange       | `function`        | `false`     | -       | Função disparada ao alterar o valor do campo de texto.                              |
-| onPressEnter   | `function`        | `false`     | -       | Função disparada ao apertar Enter dentro do campo de texto.                         |
-| startAdornment | `React.ReactNode` | `false`     | -       | Ícone ou botão com ícone que será exibido no início do campo.                       |
+Equivalente as props do componente [Input](/houston/ui-components/Forms/Input).

--- a/src/pages/ui-components/Forms/Radio/Group.tsx
+++ b/src/pages/ui-components/Forms/Radio/Group.tsx
@@ -38,7 +38,7 @@ const RadioGroup = ({ children, value, onChange, className, errorMessage }: Radi
 
   return (
     <div className={className}>
-      <div className='hst-radio-group-radios'>{mappedChildren}</div>
+      <div className='hst-radio-group-options'>{mappedChildren}</div>
       <span className='hst-radio-group-error-message'>{errorMessage}</span>
     </div>
   );
@@ -46,7 +46,7 @@ const RadioGroup = ({ children, value, onChange, className, errorMessage }: Radi
 
 export default styled(withForm(React.memo(RadioGroup)), { label: 'hst-radio-group' })`
   ${({ theme, spacing = 'xxxs' }) => css`
-    .hst-radio-group-radios {
+    .hst-radio-group-options {
       display: flex;
       flex-direction: column;
       gap: ${theme.spacing[spacing]};

--- a/src/pages/ui-components/Forms/Radio/Item.tsx
+++ b/src/pages/ui-components/Forms/Radio/Item.tsx
@@ -38,10 +38,10 @@ const RadioItem = ({
   return (
     <label
       className={cx(className, {
-        '--hst-empty': !label,
-        '--hst-checked': checked,
-        '--hst-error': !!error,
-        '--hst-disabled': disabled
+        'hst-radio-item-empty': !label,
+        'hst-radio-item-checked': checked,
+        'hst-radio-item-error': !!error,
+        'hst-radio-item-disabled': disabled
       })}
       htmlFor={props.id}
     >
@@ -66,7 +66,7 @@ export default styled(React.memo(RadioItem), { label: 'hst-radio-item' })(
     display: flex;
     cursor: pointer;
 
-    &.--hst-empty {
+    &.hst-radio-item-empty {
       display: inline-block;
       margin: 0;
     }
@@ -84,8 +84,8 @@ export default styled(React.memo(RadioItem), { label: 'hst-radio-item' })(
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 16px;
-      height: 16px;
+      width: ${theme.pxToRem(16)}rem;
+      height: ${theme.pxToRem(16)}rem;
       line-height: 0;
       border: 1px solid ${theme.neutralColor.low.light};
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
@@ -116,7 +116,7 @@ export default styled(React.memo(RadioItem), { label: 'hst-radio-item' })(
       box-shadow: 0 0 0 1px transparent;
     }
 
-    &.--hst-checked > .hst-radio-item-icon-container {
+    &.hst-radio-item-checked > .hst-radio-item-icon-container {
       color: ${theme.brandColor.primary.pure};
       background-color: white;
       border-color: ${theme.brandColor.primary.pure};
@@ -128,19 +128,19 @@ export default styled(React.memo(RadioItem), { label: 'hst-radio-item' })(
       }
     }
 
-    &.--hst-error:not(.--hst-checked) > .hst-radio-item-icon-container {
+    &.hst-radio-item-error:not(.hst-radio-item-checked) > .hst-radio-item-icon-container {
       background-color: ${theme.hexToRgba(theme.feedbackColor.negative.pure, theme.opacity.level[2])};
       border-color: ${theme.feedbackColor.negative.pure};
     }
 
-    &.--hst-error.--hst-checked > .hst-radio-item-icon-container {
+    &.hst-radio-item-error.hst-radio-item-checked > .hst-radio-item-icon-container {
       color: ${theme.feedbackColor.negative.pure};
       background-color: ${theme.hexToRgba(theme.feedbackColor.negative.pure, theme.opacity.level[2])};
       border-color: ${theme.feedbackColor.negative.pure};
       box-shadow: 0 0 0 1px ${theme.feedbackColor.negative.pure};
     }
 
-    &.--hst-disabled {
+    &.hst-radio-item-disabled {
       cursor: not-allowed;
       opacity: ${theme.opacity.level[6]};
 

--- a/src/pages/ui-components/Forms/Search/Result.tsx
+++ b/src/pages/ui-components/Forms/Search/Result.tsx
@@ -19,14 +19,14 @@ const SearchResult = ({ className, children }: SearchResultProps) => {
 
   return (
     <div ref={divRef} className={className} onClick={handleClick}>
-      <Typography className='__text' size='xs'>
+      <Typography className='hst-input-search-option-text' size='xs'>
         {children}
       </Typography>
     </div>
   );
 };
 
-export default styled(React.memo(SearchResult), { label: 'houston-form-search-option' })(
+export default styled(React.memo(SearchResult), { label: 'hst-input-search-option' })(
   ({ theme }) => css`
     cursor: pointer;
     padding: ${theme.spacing.squish.xs};
@@ -47,7 +47,7 @@ export default styled(React.memo(SearchResult), { label: 'houston-form-search-op
       border-bottom: ${theme.border.width.xs} solid ${theme.neutralColor.high.medium};
     }
 
-    & > .__text {
+    & > .hst-input-search-option-text {
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;

--- a/src/pages/ui-components/Forms/Search/index.mdx
+++ b/src/pages/ui-components/Forms/Search/index.mdx
@@ -67,23 +67,14 @@ import Search from '@eduzz/houston-ui/Forms/Search';
 
 ### Search Props
 
-| prop           | tipo                                                                | obrigatório | padrão  | descrição                                                                                                     |
-| -------------- | ------------------------------------------------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------------------------------- |
-| id             | `string`                                                            | `false`     | -       | -                                                                                                             |
-| name           | `string`                                                            | `false`     | -       |                                                                                                               |
-| label          | `string`                                                            | `false`     | -       | -                                                                                                             |
-| disabled       | `boolean`                                                           | `false`     | `false` |                                                                                                               |
-| fullWidth      | `boolean`                                                           | `false`     | `true`  |                                                                                                               |
-| className      | `string`                                                            | `false`     | -       |                                                                                                               |
-| loading        | `boolean`                                                           | `false`     | -       | Exibe ícone de carregamento no componente                                                                     |
-| helperText     | `string`                                                            | `false`     | -       | Exibe texto de ajuda abaixo do componente de seleção                                                          |
-| placeholder    | `string`                                                            | `false`     | -       |                                                                                                               |
-| errorMessage   | `string`                                                            | `false`     | -       | Exibe uma mensagem de erro no componente de seleção, assim como indica erro no campo                          |
-| value          | `string`                                                            | `false`     | -       |                                                                                                               |
-| onChange       | `(value: string, e?: React.ChangeEvent<HTMLInputElement>) => any`   | `false`     | -       |                                                                                                               |
-| onSelect       | `(value: string, e?: React.MouseEvent<HTMLDivElement>) => any`      | `false`     | -       |                                                                                                               |
-| onEnter        | `(value: string, e?: React.KeyboardEvent<HTMLInputElement>) => any` | `false`     | -       |                                                                                                               |
-| filterStrategy | `(result: string, index?: number, results?: string[]) => boolean`   | `false`     | -       | Função para filtrar os resultados informados, para que um resultado seja exibido, a função deve retornar true |
+| prop           | tipo                                                                | obrigatório | padrão | descrição                                                                                                     |
+| -------------- | ------------------------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| onChange       | `(value: string, e?: React.ChangeEvent<HTMLInputElement>) => any`   | `false`     | -      |                                                                                                               |
+| onSelect       | `(value: string, e?: React.MouseEvent<HTMLDivElement>) => any`      | `false`     | -      |                                                                                                               |
+| onEnter        | `(value: string, e?: React.KeyboardEvent<HTMLInputElement>) => any` | `false`     | -      |                                                                                                               |
+| filterStrategy | `(result: string, index?: number, results?: string[]) => boolean`   | `false`     | -      | Função para filtrar os resultados informados, para que um resultado seja exibido, a função deve retornar true |
+
+E as props do componente [Input](/houston/ui-components/Forms/Input).
 
 ### Search.Result Props
 

--- a/src/pages/ui-components/Forms/Search/index.tsx
+++ b/src/pages/ui-components/Forms/Search/index.tsx
@@ -126,7 +126,7 @@ const SearchField = React.forwardRef<HTMLInputElement, SearchFieldProps>(
           startAdornment={<SearchOutlineIcon size='md' />}
           endAdornment={
             <IconButton
-              className={clsx(shouldHideCleanBtn && '--hidden')}
+              className={clsx(shouldHideCleanBtn && 'hst-input-search-hidden')}
               aria-hidden={shouldHideCleanBtn}
               hidden={shouldHideCleanBtn}
               onClick={resetField}
@@ -150,7 +150,7 @@ const SearchField = React.forwardRef<HTMLInputElement, SearchFieldProps>(
             disabled={disabled}
             placeholder={placeholder}
             value={value}
-            className='__input'
+            className='hst-input-search-input'
           />
         </Fieldset>
       </SearchContextProvider>
@@ -158,12 +158,12 @@ const SearchField = React.forwardRef<HTMLInputElement, SearchFieldProps>(
   }
 );
 
-const StyledSearchField = styled(withForm(SearchField), { label: 'hostoun-form-search-field' })`
+const StyledSearchField = styled(withForm(SearchField), { label: 'hst-input-search' })`
   ${({ theme }) => css`
-    .__content {
+    .hst-fieldset-content {
       overflow: hidden;
 
-      .__input {
+      .hst-input-search-input {
         width: 100%;
         white-space: nowrap;
         overflow: hidden;
@@ -183,7 +183,7 @@ const StyledSearchField = styled(withForm(SearchField), { label: 'hostoun-form-s
       }
     }
 
-    .--hidden {
+    .hst-input-search-hidden {
       visibility: hidden;
     }
   `}

--- a/src/pages/ui-components/Forms/Select/Option.tsx
+++ b/src/pages/ui-components/Forms/Select/Option.tsx
@@ -43,14 +43,14 @@ const SelectOption = ({ children, value, label, className, disabled, id }: Selec
       id={id}
       ref={divRef}
       className={cx(className, {
-        [`--size-${inputSize ?? 'default'}`]: true,
-        '--disabled': disabled
+        [`hst-select-option-size-${inputSize ?? 'default'}`]: true,
+        'hst-select-option-disabled': disabled
       })}
       onClick={handleClick}
     >
-      <div className='__content'>
-        {multiple && !isEmptyOption && <Checkbox checked={isSelected} className='__checkbox' />}
-        {multiple && isEmptyOption && <Cancel className='__icon' />}
+      <div className='hst-select-option-content'>
+        {multiple && !isEmptyOption && <Checkbox checked={isSelected} className='hst-select-option-checkbox' />}
+        {multiple && isEmptyOption && <Cancel className='hst-select-option-icon' />}
 
         {typeof children === 'string' ? (
           <Typography size={inputSize === 'sm' ? 'xxs' : 'xs'} weight={isSelected ? 'semibold' : 'regular'}>
@@ -64,7 +64,7 @@ const SelectOption = ({ children, value, label, className, disabled, id }: Selec
   );
 };
 
-export default styled(React.memo(SelectOption), { label: 'houston-form-select-option' })(
+export default styled(React.memo(SelectOption), { label: 'hst-select-option' })(
   ({ theme }) => css`
     cursor: pointer;
     padding: ${theme.spacing.squish.xs};
@@ -85,26 +85,26 @@ export default styled(React.memo(SelectOption), { label: 'houston-form-select-op
       border-bottom: ${theme.border.width.xs} solid ${theme.neutralColor.high.medium};
     }
 
-    & > .__content {
+    & > .hst-select-option-content {
       display: flex;
       align-items: center;
 
-      & > .__checkbox,
-      & > .__icon {
+      & > .hst-select-option-checkbox,
+      & > .hst-select-option-icon {
         margin-right: ${theme.spacing.nano};
       }
     }
 
-    &.--disabled {
+    &.hst-select-option-disabled {
       cursor: not-allowed;
 
-      & > .__content {
+      & > .hst-select-option-content {
         opacity: ${theme.opacity.level[6]};
         pointer-events: none;
       }
     }
 
-    &.--size-sm {
+    &.hst-select-option-size-sm {
       padding: ${theme.spacing.squish.xxs};
 
       &:not(:last-child):after {

--- a/src/pages/ui-components/Forms/Select/index.tsx
+++ b/src/pages/ui-components/Forms/Select/index.tsx
@@ -153,7 +153,7 @@ const SelectField = ({
         disabled={disabled}
         onClickContainer={!disabled && !loading ? openPopover : undefined}
       >
-        <div id={id} className='__text'>
+        <div id={id} className='hst-input-text'>
           {text}
         </div>
       </Fieldset>

--- a/src/pages/ui-components/Forms/Switch/index.mdx
+++ b/src/pages/ui-components/Forms/Switch/index.mdx
@@ -55,10 +55,6 @@ import Switch from '@eduzz/houston-ui/Forms/Switch';
 
 ### Utilizando com Form
 
-```js
-import useForm from '@eduzz/houston-forms/useForm';
-```
-
 <Playground>
   {() => {
     const form = useForm({ defaultValues: { switch: true } });

--- a/src/pages/ui-components/Forms/Switch/index.tsx
+++ b/src/pages/ui-components/Forms/Switch/index.tsx
@@ -15,6 +15,13 @@ export interface SwitchProps
   errorMessage?: string;
 }
 
+const WIDTH_IN_PX = 40;
+const HEIGHT_IN_PX = 24;
+
+const THUMB_WIDTH_IN_PX = 16;
+const THUMB_HEIGHT_IN_PX = 16;
+const THUMB_OFFSET_IN_REM = 1;
+
 const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
   ({ children, className, onChange, disabled, value, id: idProp, errorMessage, ...rest }, ref) => {
     const handleChange = React.useCallback(() => {
@@ -24,11 +31,11 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
     const [id] = React.useState(idProp ?? `hst-switch-id-${Math.floor(Math.random() * 1000)}`);
 
     return (
-      <div className={cx(className, { '--hst-switch-disabled': disabled })}>
+      <div className={cx(className, { 'hst-switch-disabled': disabled })}>
         <button
           id={id}
           role='switch'
-          className={cx('hst-switch__button', { '--error': !!errorMessage })}
+          className={cx('hst-switch-button', { 'hst-switch-error': !!errorMessage })}
           onClick={handleChange}
           disabled={disabled}
           aria-disabled={disabled}
@@ -38,30 +45,23 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         >
           <div
             tabIndex={0}
-            className={cx('hst-switch__track', {
-              '--checked': value,
-              '--error': !!errorMessage
+            className={cx('hst-switch-track', {
+              'hst-switch-checked': value,
+              'hst-switch-error': !!errorMessage
             })}
           >
-            <span className={cx('hst-switch__thumb', { '--checked': value })} />
+            <span className={cx('hst-switch-thumb', { 'hst-switch-checked': value })} />
           </div>
         </button>
 
-        <div className='__label'>
+        <div className='hst-switch-label'>
           {children && <label htmlFor={id}>{children}</label>}
-          {!!errorMessage && <div className='hst-switch__errorMessage'>{errorMessage}</div>}
+          {!!errorMessage && <div className='hst-switch-error-message'>{errorMessage}</div>}
         </div>
       </div>
     );
   }
 );
-
-const WIDTH_IN_PX = 40;
-const HEIGHT_IN_PX = 24;
-
-const THUMB_WIDTH_IN_PX = 16;
-const THUMB_HEIGHT_IN_PX = 16;
-const THUMB_OFFSET_IN_REM = 1;
 
 export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => {
   return css`
@@ -71,12 +71,12 @@ export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => 
     cursor: pointer;
     line-height: ${theme.line.height.lg};
 
-    &.--hst-switch-disabled {
+    &.hst-switch-disabled {
       opacity: ${theme.opacity.level[6]};
       cursor: not-allowed;
     }
 
-    .hst-switch__errorMessage {
+    .hst-switch-error-message {
       font-size: ${theme.font.size.xxs};
       font-family: ${theme.font.family.base};
       font-weight: ${theme.font.weight.regular};
@@ -84,7 +84,7 @@ export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => 
       color: ${theme.hexToRgba(theme.feedbackColor.negative.pure)};
     }
 
-    .hst-switch__button {
+    .hst-switch-button {
       all: unset;
       margin-bottom: auto;
 
@@ -93,17 +93,19 @@ export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => 
       }
     }
 
-    label {
-      all: unset;
-      color: ${theme.neutralColor.low.pure};
-      font-family: ${theme.font.family.base};
-      font-size: ${theme.font.size.xs};
-      font-weight: ${theme.font.weight.regular};
-      line-height: ${theme.line.height.default};
-      user-select: none;
+    .hst-switch-label {
+      label {
+        all: unset;
+        color: ${theme.neutralColor.low.pure};
+        font-family: ${theme.font.family.base};
+        font-size: ${theme.font.size.xs};
+        font-weight: ${theme.font.weight.regular};
+        line-height: ${theme.line.height.default};
+        user-select: none;
+      }
     }
 
-    .hst-switch__track {
+    .hst-switch-track {
       width: ${theme.pxToRem(WIDTH_IN_PX)}rem;
       height: ${theme.pxToRem(HEIGHT_IN_PX)}rem;
       background-color: ${theme.hexToRgba(theme.neutralColor.low.light, theme.opacity.level[8])};
@@ -123,15 +125,15 @@ export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => 
         outline: ${theme.border.width.sm} solid ${theme.feedbackColor.informative.pure};
       }
 
-      &.--checked {
+      &.hst-switch-checked {
         background-color: ${theme.brandColor.primary.pure};
       }
 
-      &.--error {
+      &.hst-switch-error {
         background-color: ${theme.hexToRgba(theme.feedbackColor.negative.pure)};
       }
 
-      .hst-switch__thumb {
+      .hst-switch-thumb {
         width: ${theme.pxToRem(THUMB_WIDTH_IN_PX)}rem;
         height: ${theme.pxToRem(THUMB_HEIGHT_IN_PX)}rem;
         background-color: ${theme.neutralColor.high.pure};
@@ -140,7 +142,7 @@ export default styled(withForm(Switch), { label: 'hst-switch' })(({ theme }) => 
         transition: all 0.2s;
         left: ${theme.spacing.quarck};
 
-        &.--checked {
+        &.hst-switch-checked {
           transform: translateX(${THUMB_OFFSET_IN_REM}rem);
         }
       }

--- a/src/pages/ui-components/Forms/Text/index.tsx
+++ b/src/pages/ui-components/Forms/Text/index.tsx
@@ -3,7 +3,7 @@ import Input, { InputProps } from '../Input';
 export interface TextProps extends InputProps {}
 
 /**
- * @deprecated Migrar para o Input
+ * @deprecated Migrate to Input
  */
 const Text = (props: TextProps) => {
   return <Input {...props} />;

--- a/src/pages/ui-components/Forms/_utils/Fieldset.tsx
+++ b/src/pages/ui-components/Forms/_utils/Fieldset.tsx
@@ -57,31 +57,31 @@ const Fieldset = React.forwardRef<HTMLFieldSetElement, InternalFieldsetProps>(
         id={id}
         ref={ref}
         className={cx(className, {
-          '--hidden': hidden,
-          '--full-width': fullWidth ?? true,
-          '--error': !!errorMessage,
-          '--disabled': disabled,
-          '--loading': loading,
-          '--focused': focused,
-          '--clickable': !!onClickContainer,
-          [`--size-${size ?? 'default'}`]: true
+          'hst-fieldset-hidden': hidden,
+          'hst-fieldset-full-width': fullWidth ?? true,
+          'hst-fieldset-error': !!errorMessage,
+          'hst-fieldset-disabled': disabled,
+          'hst-fieldset-loading': loading,
+          'hst-fieldset-focused': focused,
+          'hst-fieldset-clickable': !!onClickContainer,
+          [`hst-fieldset-size-${size ?? 'default'}`]: true
         })}
       >
-        {!!label && <label className='__label'>{label}</label>}
+        {!!label && <label className='hst-fieldset-label'>{label}</label>}
 
-        <div className='__container' ref={containerRef} onClick={onClickContainer}>
-          {!!startAdornment && <span className='__startAdornment'>{startAdornment}</span>}
-          <div className='__content'>{children}</div>
-          {!!endAdornment && <span className='__endAdornment'>{endAdornment}</span>}
+        <div className='hst-fieldset-container' ref={containerRef} onClick={onClickContainer}>
+          {!!startAdornment && <span className='hst-fieldset-start-adornment'>{startAdornment}</span>}
+          <div className='hst-fieldset-content'>{children}</div>
+          {!!endAdornment && <span className='hst-fieldset-end-adornment'>{endAdornment}</span>}
         </div>
 
-        {!!helperText && <span className='__message'>{helperText}</span>}
+        {!!helperText && <span className='hst-fieldset-message'>{helperText}</span>}
       </fieldset>
     );
   }
 );
 
-export default styled(Fieldset, { label: 'houston-form-fieldset' })(
+export default styled(Fieldset, { label: 'hst-fieldset' })(
   ({ theme }) => css`
     border: none;
     position: relative;
@@ -91,7 +91,7 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
     display: inline-block;
     vertical-align: top;
 
-    & > .__container {
+    & > .hst-fieldset-container {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -103,8 +103,8 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
       height: 48px;
       box-shadow: 0 0 0 2px transparent;
 
-      & > .__startAdornment,
-      & > .__endAdornment {
+      & > .hst-fieldset-start-adornment,
+      & > .hst-fieldset-end-adornment {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -115,19 +115,19 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
         }
       }
 
-      & > .__content {
+      & > .hst-fieldset-content {
         width: 100%;
       }
 
-      & > .__startAdornment {
+      & > .hst-fieldset-start-adornment {
         margin-left: ${theme.spacing.xxxs};
       }
 
-      & > .__endAdornment {
+      & > .hst-fieldset-end-adornment {
         margin-right: ${theme.spacing.xxxs};
       }
 
-      & .__text {
+      & .hst-input-text {
         padding: ${theme.spacing.squish.xxs};
         font-size: ${theme.font.size.xs};
         font-family: ${theme.font.family.base};
@@ -137,7 +137,7 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
       }
     }
 
-    & > .__label {
+    & > .hst-fieldset-label {
       font-size: ${theme.font.size.xs};
       font-family: ${theme.font.family.base};
       font-weight: ${theme.font.weight.regular};
@@ -148,7 +148,7 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
       align-items: center;
     }
 
-    & > .__message {
+    & > .hst-fieldset-message {
       display: block;
       font-size: ${theme.font.size.xxs};
       font-family: ${theme.font.family.base};
@@ -158,61 +158,61 @@ export default styled(Fieldset, { label: 'houston-form-fieldset' })(
       margin-top: ${theme.spacing.nano};
     }
 
-    &.--clickable:not(.--disabled) > .__container {
+    &.hst-fieldset-clickable:not(.hst-fieldset-disabled) > .hst-fieldset-container {
       cursor: pointer;
       user-select: none;
     }
 
-    &.--disabled {
+    &.hst-fieldset-disabled {
       opacity: ${theme.opacity.level[6]};
       cursor: not-allowed;
     }
 
-    &.--hidden {
+    &.hst-fieldset-hidden {
       display: none;
     }
 
-    &:not(.--disabled) > .__container:hover {
+    &:not(.hst-fieldset-disabled) > .hst-fieldset-container:hover {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
     }
 
-    &.--loading {
+    &.hst-fieldset-loading {
       cursor: progress;
     }
 
-    &.--focused {
-      & > .__container {
+    &.hst-fieldset-focused {
+      & > .hst-fieldset-container {
         box-shadow: 0 0 0 2px ${theme.feedbackColor.informative.pure};
         background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       }
     }
 
-    &.--error > .__container {
+    &.hst-fieldset-error > .hst-fieldset-container {
       background-color: ${theme.hexToRgba(theme.feedbackColor.negative.pure, theme.opacity.level[2])};
       border-color: ${theme.feedbackColor.negative.pure};
     }
 
-    &.--full-width {
+    &.hst-fieldset-full-width {
       width: 100%;
     }
 
-    &.--size-sm {
+    &.hst-fieldset-size-sm {
       margin: 0;
 
-      & .__container {
+      & .hst-fieldset-container {
         height: 35px;
 
-        & > .__startAdornment {
+        & > .hst-fieldset-start-adornment {
           margin-left: ${theme.spacing.nano};
         }
 
-        & > .__endAdornment {
+        & > .hst-fieldset-end-adornment {
           margin-right: ${theme.spacing.nano};
         }
       }
 
-      & .__text,
-      & > .__label {
+      & .hst-input-text,
+      & > .hst-fieldset-label {
         font-size: ${theme.font.size.xxs};
       }
     }

--- a/src/pages/ui-components/Grid/Column/index.tsx
+++ b/src/pages/ui-components/Grid/Column/index.tsx
@@ -20,12 +20,12 @@ const Column = React.forwardRef<HTMLDivElement, ColumnProps>(
         ref={ref}
         className={cx(
           className,
-          '__houston_grid_column',
-          xs && `--xs-${xs}`,
-          sm && `--sm-${sm}`,
-          md && `--md-${md}`,
-          lg && `--lg-${lg}`,
-          xlg && `--xlg-${xlg}`
+          'hst-grid-column',
+          xs && `hst-grid-column-xs-${xs}`,
+          sm && `hst-grid-column-sm-${sm}`,
+          md && `hst-grid-column-md-${md}`,
+          lg && `hst-grid-column-lg-${lg}`,
+          xlg && `hst-grid-column-xlg-${xlg}`
         )}
       >
         {children}
@@ -34,11 +34,11 @@ const Column = React.forwardRef<HTMLDivElement, ColumnProps>(
   }
 );
 
-export default styled(Column, { label: 'houston-grid-column' })(({ theme }) =>
+export default styled(Column, { label: 'hst-grid-column' })(({ theme }) =>
   breakpoints.map(breakpoint => {
     const cssSize = columnSizes.map(
       size => css`
-        &.--${breakpoint}-${size} {
+        &.hst-grid-column-${breakpoint}-${size} {
           flex-basis: ${typeof size === 'string' ? 'auto' : `${(size / COLUMNS) * 100}%`};
           flex: ${size === 'fill' ? 1 : null};
         }

--- a/src/pages/ui-components/Grid/Container/index.tsx
+++ b/src/pages/ui-components/Grid/Container/index.tsx
@@ -9,18 +9,18 @@ export interface ContainerProps extends StyledProp {
 }
 
 const Container = React.forwardRef<HTMLDivElement, ContainerProps>(({ className, children, layout }, ref) => (
-  <div ref={ref} className={cx(className, `--layout-${layout ?? 'solid'}`)}>
+  <div ref={ref} className={cx(className, `hst-grid-container-${layout ?? 'solid'}`)}>
     {children}
   </div>
 ));
 
-export default styled(Container, { label: 'houston-grid-container' })(
+export default styled(Container, { label: 'hst-grid-container' })(
   ({ theme }) => css`
     width: 100%;
     max-width: ${theme.breakpoints.xlg};
     margin: 0 auto;
 
-    &.--layout-fluid {
+    &.hst-grid-container-fluid {
       max-width: 100%;
     }
   `

--- a/src/pages/ui-components/Grid/Row/index.tsx
+++ b/src/pages/ui-components/Grid/Row/index.tsx
@@ -27,9 +27,9 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>(
         ref={ref}
         className={cx(
           className,
-          `--spacing-${spacing}`,
-          `--justify-content-${justifyContent}`,
-          `--align-items-${alignItems}`
+          `hst-grid-row-spacing-${spacing}`,
+          `hst-grid-row-justify-content-${justifyContent}`,
+          `hst-grid-row-align-items-${alignItems}`
         )}
       >
         {children}
@@ -38,14 +38,14 @@ const Row = React.forwardRef<HTMLDivElement, RowProps>(
   }
 );
 
-export default styled(Row, { label: 'houston-grid-row' })(
+export default styled(Row, { label: 'hst-grid-row' })(
   ({ theme }) => css`
     display: flex;
     flex-wrap: wrap;
 
     ${justifyContent.map(
       justifyContent => css`
-        &.--justify-content-${justifyContent} {
+        &.hst-grid-row-justify-content-${justifyContent} {
           justify-content: ${justifyContent};
         }
       `
@@ -53,7 +53,7 @@ export default styled(Row, { label: 'houston-grid-row' })(
 
     ${alignItems.map(
       alignItems => css`
-        &.--align-items-${alignItems} {
+        &.hst-grid-row-align-items-${alignItems} {
           align-items: ${alignItems};
         }
       `
@@ -61,11 +61,11 @@ export default styled(Row, { label: 'houston-grid-row' })(
 
     ${spacing.map(
       spacing => css`
-        &.--spacing-${spacing} {
+        &.hst-grid-row-spacing-${spacing} {
           width: calc(100% + ${theme.spacing.inline[spacing] ?? '0rem'});
           margin: calc(-${theme.spacing.inline[spacing] ?? '0rem'} / 2);
 
-          & > .__houston_grid_column {
+          & > .hst-grid-column {
             box-sizing: border-box;
             padding: calc(${theme.spacing.inline[spacing] ?? '0rem'} / 2);
           }

--- a/src/pages/ui-components/IconButton/index.tsx
+++ b/src/pages/ui-components/IconButton/index.tsx
@@ -32,12 +32,18 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     <button
       role='button'
       disabled={disabled}
-      className={cx(className, `--hst-${size ?? 'lg'}`, { '--hst-active': active })}
+      className={cx(className, `hst-icon-button-size-${size ?? 'lg'}`, { 'hst-icon-button-active': active })}
       aria-disabled={disabled}
       {...rest}
       ref={ref}
     >
-      <div className={cx('__hst-icon', `--hst-${size ?? 'lg'}`, { '--hst-disabled': disabled })}>{children}</div>
+      <div
+        className={cx('hst-icon-button', `hst-icon-button-size-${size ?? 'lg'}`, {
+          'hst-icon-button-disabled': disabled
+        })}
+      >
+        {children}
+      </div>
     </button>
   )
 );
@@ -48,7 +54,7 @@ const LG_ICON_SIZE = 24;
 const MD_SIZE = 32;
 const MD_ICON_SIZE = 16;
 
-export default styled(IconButton, { label: 'houston-icon-button' })`
+export default styled(IconButton, { label: 'hst-icon-button' })`
   ${({ theme }) => css`
     border: none;
     background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
@@ -62,15 +68,15 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
       transition: 0.3s;
     }
 
-    &.--hst-lg,
-    &.--hst-large {
+    &.hst-icon-button-size-lg,
+    &.hst-icon-button-size-large {
       width: ${theme.pxToRem(LG_SIZE)}rem;
       height: ${theme.pxToRem(LG_SIZE)}rem;
     }
 
-    &.--hst-md,
-    &.--hst-medium,
-    &.--hst-small {
+    &.hst-icon-button-size-md,
+    &.hst-icon-button-size-medium,
+    &.hst-icon-button-size-small {
       width: ${theme.pxToRem(MD_SIZE)}rem;
       height: ${theme.pxToRem(MD_SIZE)}rem;
     }
@@ -79,18 +85,18 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
       cursor: default;
     }
 
-    .__hst-icon {
+    .hst-icon-button {
       display: flex;
       align-items: center;
       justify-content: center;
 
-      &.--hst-disabled {
+      &.hst-icon-button-disabled {
         fill: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
         color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[6])};
       }
 
-      &.--hst-lg,
-      &.--hst-large {
+      &.hst-icon-button-size-lg,
+      &.hst-icon-button-size-large {
         width: ${theme.pxToRem(LG_ICON_SIZE)}rem;
         height: ${theme.pxToRem(LG_ICON_SIZE)}rem;
 
@@ -100,9 +106,9 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
         }
       }
 
-      &.--hst-md,
-      &.--hst-medium,
-      &.--hst-small {
+      &.hst-icon-button-size-md,
+      &.hst-icon-button-size-medium,
+      &.hst-icon-button-size-small {
         width: ${theme.pxToRem(MD_ICON_SIZE)}rem;
         height: ${theme.pxToRem(MD_ICON_SIZE)}rem;
 
@@ -119,7 +125,7 @@ export default styled(IconButton, { label: 'houston-icon-button' })`
 
     &:hover:not(:disabled),
     &:focus,
-    &.--hst-active {
+    &.hst-icon-button-active {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
     }
   `}

--- a/src/pages/ui-components/Image/Thumbnail/index.tsx
+++ b/src/pages/ui-components/Image/Thumbnail/index.tsx
@@ -11,29 +11,29 @@ export interface ThumbnailProps extends ImageProps {
 }
 
 const Thumbnail = React.forwardRef<HTMLImageElement, ThumbnailProps>(({ size = 'md', className, ...props }, ref) => {
-  return <Image ref={ref} className={cx(className, size && `--${size}`)} {...props} />;
+  return <Image ref={ref} className={cx(className, size && `hst-thumbnail-size-${size}`)} {...props} />;
 });
 
-export default styled(Thumbnail, { label: 'houston-thumbnail' })`
+export default styled(Thumbnail, { label: 'hst-thumbnail' })`
   ${({ theme }) => css`
     border-radius: ${theme.border.radius.xs};
 
-    &.--xl {
+    &.hst-thumbnail-size-xl {
       width: ${theme.pxToRem(80)}rem;
       height: ${theme.pxToRem(80)}rem;
     }
 
-    &.--lg {
+    &.hst-thumbnail-size-lg {
       width: ${theme.pxToRem(64)}rem;
       height: ${theme.pxToRem(64)}rem;
     }
 
-    &.--md {
+    &.hst-thumbnail-size-md {
       width: ${theme.pxToRem(40)}rem;
       height: ${theme.pxToRem(40)}rem;
     }
 
-    &.--sm {
+    &.hst-thumbnail-size-sm {
       width: ${theme.pxToRem(24)}rem;
       height: ${theme.pxToRem(24)}rem;
     }

--- a/src/pages/ui-components/Image/index.mdx
+++ b/src/pages/ui-components/Image/index.mdx
@@ -36,8 +36,8 @@ import Image from '@eduzz/houston-ui/Image';
 
 Possui todas propriedades de uma tag `<img />` comum e:
 
-| prop        | tipo                                               | obrigatório | padrão | descrição                                                                                                                                  |
-| ----------- | -------------------------------------------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| src         | `string`                                           | `true`      | -      | Caminho da imagem.                                                                                                                         |
-| fallbackSrc | `string`                                           | `false`     | -      | Caminho para imagem quando a imagem principal não estiver carregada ou não carregar. É recomendável usar um caminho para uma imagem local. |
-| fit         | `'fill', 'contain', 'cover', 'none', 'scale-down'` | `false`     | -      | -                                                                                                                                          |
+| prop        | tipo        | obrigatório | padrão | descrição                                                                                                                                  |
+| ----------- | ----------- | ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| src         | `string`    | `true`      | -      | Caminho da imagem.                                                                                                                         |
+| fallbackSrc | `string`    | `false`     | -      | Caminho para imagem quando a imagem principal não estiver carregada ou não carregar. É recomendável usar um caminho para uma imagem local. |
+| fit         | `ImageFits` | `false`     | -      | -                                                                                                                                          |

--- a/src/pages/ui-components/Image/index.tsx
+++ b/src/pages/ui-components/Image/index.tsx
@@ -27,32 +27,32 @@ const ImageComponent = React.forwardRef<HTMLImageElement, ImageProps>(
       image.onload = () => setSrc(srcProp);
     }, [srcProp, fallbackSrc]);
 
-    return <img ref={ref} className={cx(className, fit && `--fit-${fit}`)} src={src} {...props} />;
+    return <img ref={ref} className={cx(className, fit && `hst-image-fit-${fit}`)} src={src} {...props} />;
   }
 );
 
-const StyledImage = styled(ImageComponent, { label: 'houston-image' })`
+const StyledImage = styled(ImageComponent, { label: 'hst-image' })`
   display: block;
   max-width: 100%;
   height: auto;
 
-  &.--fit-fill {
+  &.hst-image-fit-fill {
     object-fit: fill;
   }
 
-  &.--fit-contain {
+  &.hst-image-fit-contain {
     object-fit: contain;
   }
 
-  &.--fit-cover {
+  &.hst-image-fit-cover {
     object-fit: cover;
   }
 
-  &.--fit-none {
+  &.hst-image-fit-none {
     object-fit: none;
   }
 
-  &.--fit-scale-down {
+  &.hst-image-fit-scale-down {
     object-fit: scale-down;
   }
 `;

--- a/src/pages/ui-components/Layout/Content/index.tsx
+++ b/src/pages/ui-components/Layout/Content/index.tsx
@@ -8,15 +8,15 @@ export interface LayoutContentProps extends StyledProp {
 }
 
 const LayoutContent = ({ children, className, disablePadding }: LayoutContentProps) => {
-  return <div className={cx(className, { '--disable-padding': disablePadding })}>{children}</div>;
+  return <div className={cx(className, { 'hst-sidebar-content-disable-padding': disablePadding })}>{children}</div>;
 };
 
-export default styled(LayoutContent, { label: 'houston-sidebar-content' })(
+export default styled(LayoutContent, { label: 'hst-sidebar-content' })(
   ({ theme }) => css`
     flex: 1;
     min-width: 0;
 
-    &:not(.--disable-padding) {
+    &:not(.hst-sidebar-content-disable-padding) {
       padding: ${theme.spacing.stack.lg} ${theme.spacing.xs};
 
       ${theme.breakpoints.down('md')} {

--- a/src/pages/ui-components/Layout/Layout.tsx
+++ b/src/pages/ui-components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import useBoolean from '@eduzz/houston-hooks/useBoolean';
-import { cx, StyledProp } from '@eduzz/houston-styles';
+import { css, cx, StyledProp } from '@eduzz/houston-styles';
 
 import nestedComponent from '../utils/nestedComponent';
 import Content from './Content';
@@ -90,19 +90,21 @@ const Layout = ({ className, children }: LayoutProps) => {
 
   return (
     <LayoutContext.Provider value={contextValue}>
-      <div className={cx(className, { '--hasTopbar': hasTopbar })}>{children}</div>
+      <div className={cx(className, { 'hst-layout-has-topbar': hasTopbar })}>{children}</div>
     </LayoutContext.Provider>
   );
 };
 
-const LayoutWrapper = styled(Layout, { label: 'houston-layout' })`
-  display: flex;
-  width: 100%;
-  min-height: 100vh;
+const LayoutWrapper = styled(Layout, { label: 'hst-layout' })`
+  ${({ theme }) => css`
+    display: flex;
+    width: 100%;
+    min-height: 100vh;
 
-  &.--hasTopbar {
-    padding-top: ${TOPBAR_HEIGHT}px;
-  }
+    &.hst-layout-has-topbar {
+      padding-top: ${theme.pxToRem(TOPBAR_HEIGHT)}rem;
+    }
+  `}
 `;
 
 export default nestedComponent(LayoutWrapper, {

--- a/src/pages/ui-components/Layout/Sidebar/Group/index.tsx
+++ b/src/pages/ui-components/Layout/Sidebar/Group/index.tsx
@@ -25,14 +25,14 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({ className, children, label,
     <SidebarGroupContext.Provider value={contextValue}>
       <li className={className}>
         {!!label && (
-          <div className='houston-sidebar-group__item' onClick={toogleExpanded} tabIndex={tabIndex ?? 1}>
-            <div className={cx('houston-sidebar-group__arrow', isExpanded && '--rotate')}>
+          <div className='hst-sidebar-group-item' onClick={toogleExpanded} tabIndex={tabIndex ?? 1}>
+            <div className={cx('hst-sidebar-group-arrow', isExpanded && 'hst-sidebar-group-rotate')}>
               <ChevronDownIcon size='md' />
             </div>
 
-            <div className='houston-sidebar-group__content'>
+            <div className='hst-sidebar-group-content'>
               <Typography
-                className='houston-sidebar-group__label'
+                className='hst-sidebar-group-label'
                 color='neutralColor.low.medium'
                 weight='regular'
                 size='xxs'
@@ -44,7 +44,7 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({ className, children, label,
           </div>
         )}
 
-        <ul className='houston-sidebar-group__items'>
+        <ul className='hst-sidebar-group-items'>
           <Collapse timeout={350} visibled={isExpanded}>
             {children}
           </Collapse>
@@ -54,11 +54,11 @@ const SidebarGroup: React.FC<SidebarGroupProps> = ({ className, children, label,
   );
 };
 
-export default styled(React.memo(SidebarGroup), { label: 'houston-sidebar-group' })(
+export default styled(React.memo(SidebarGroup), { label: 'hst-sidebar-group' })(
   ({ theme }) => css`
     margin-bottom: ${theme.spacing.stack.xxxs};
 
-    .houston-sidebar-group__item {
+    .hst-sidebar-group-item {
       padding: ${theme.spacing.squish.xxs};
       display: grid;
       grid-template-columns: ${theme.pxToRem(26)}rem 1fr;
@@ -83,21 +83,21 @@ export default styled(React.memo(SidebarGroup), { label: 'houston-sidebar-group'
         background-color: rgba(0, 0, 0, 0.12);
       }
 
-      & .houston-sidebar-group__arrow {
+      & .hst-sidebar-group-arrow {
         line-height: 0;
 
         transition: 0.15s linear;
         text-align: center;
 
-        &.--rotate {
+        &.hst-sidebar-group-rotate {
           transform: rotateX(180deg);
         }
       }
 
-      & .houston-sidebar-group__content {
+      & .hst-sidebar-group-content {
         min-width: 0;
 
-        & .houston-sidebar-group__label {
+        & .hst-sidebar-group-label {
           text-transform: uppercase;
           white-space: nowrap;
           word-break: break-all;
@@ -107,7 +107,7 @@ export default styled(React.memo(SidebarGroup), { label: 'houston-sidebar-group'
       }
     }
 
-    & .houston-sidebar-group__items {
+    & .hst-sidebar-group-items {
       margin: 0;
       padding: 0;
 

--- a/src/pages/ui-components/Layout/Sidebar/Item/index.tsx
+++ b/src/pages/ui-components/Layout/Sidebar/Item/index.tsx
@@ -46,11 +46,17 @@ const SidebarItem = ({
 
   return React.createElement(
     Component ?? 'a',
-    { ...rest, to, tabIndex: tabIndex ?? 1, className: cx(className, { '--active': active, '--disabled': disabled }) },
+    {
+      ...rest,
+      to,
+      tabIndex: tabIndex ?? 1,
+      className: cx(className, { 'hst-sidebar-item-active': active, 'hst-sidebar-item-disabled': disabled })
+    },
     <li>
-      <Bullet className='houston-sidebar-item__icon' size='md' />
+      <Bullet className='hst-sidebar-item-icon' size='md' />
+
       <Typography
-        className='houston-sidebar-item__label'
+        className='hst-sidebar-item-label'
         size='xs'
         color='neutralColor.low.pure'
         lineHeight='lg'
@@ -62,7 +68,7 @@ const SidebarItem = ({
   );
 };
 
-export default styled(React.memo(SidebarItem), { label: 'houston-sidebar-item' })(
+export default styled(React.memo(SidebarItem), { label: 'hst-sidebar-item' })(
   ({ theme }) => css`
     transition: 0.15s linear;
     display: block;
@@ -93,7 +99,7 @@ export default styled(React.memo(SidebarItem), { label: 'houston-sidebar-item' }
       white-space: nowrap;
       margin-bottom: ${theme.spacing.stack.xxxs};
 
-      & .houston-sidebar-item__label {
+      & .hst-sidebar-item-label {
         grid-column: 2;
         transition: 0.15s ease-in;
         overflow: hidden;
@@ -101,7 +107,7 @@ export default styled(React.memo(SidebarItem), { label: 'houston-sidebar-item' }
         min-width: 0;
       }
 
-      & .houston-sidebar-item__icon {
+      & .hst-sidebar-item-icon {
         transform: scale(0);
         opacity: 0;
         transition: 0.15s ease-in;
@@ -109,21 +115,20 @@ export default styled(React.memo(SidebarItem), { label: 'houston-sidebar-item' }
       }
     }
 
-    &.--active > li {
+    &.hst-sidebar-item-active > li {
       &::before {
         background: ${theme.brandColor.secondary.pure};
       }
 
-      & .houston-sidebar-item__icon {
+      & .hst-sidebar-item-icon {
         transform: scale(1);
         opacity: 1;
       }
     }
 
-    &.--disabled {
+    &.hst-sidebar-item-disabled {
       opacity: ${theme.opacity.level[6]};
       pointer-events: none;
     }
   `
-  // Por causa da prop `[key: string]` estava perdendo as outras props definidas
 ) as typeof SidebarItem;

--- a/src/pages/ui-components/Layout/Sidebar/index.tsx
+++ b/src/pages/ui-components/Layout/Sidebar/index.tsx
@@ -48,10 +48,12 @@ const Sidebar = ({ currentLocation, children, className }: SidebarProps) => {
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <div className={cx(className, { '--visible': opened && isMobile, '--has-topbar': hasTopbar })}>
+      <div
+        className={cx(className, { 'hst-sidebar-visible': opened && isMobile, 'hst-sidebar-has-topbar': hasTopbar })}
+      >
         <Overlay visible={opened && isMobile} color='high' onClick={toggleMenu} underTopbar />
 
-        <aside className='houston-menu__container'>
+        <aside className='hst-sidebar-container'>
           <nav>
             <ul>{children}</ul>
           </nav>
@@ -61,13 +63,13 @@ const Sidebar = ({ currentLocation, children, className }: SidebarProps) => {
   );
 };
 
-const SidebarStyled = styled(Sidebar, { label: 'houston-menu' })`
+const SidebarStyled = styled(Sidebar, { label: 'hst-sidebar' })`
   ${({ theme }) => css`
     width: ${MENU_WIDTH}px;
     height: auto;
     position: relative;
 
-    & .houston-menu__container {
+    & .hst-sidebar-container {
       background: #fff;
       display: inline-flex;
       flex-direction: column;
@@ -110,21 +112,21 @@ const SidebarStyled = styled(Sidebar, { label: 'houston-menu' })`
       }
     }
 
-    &.--has-topbar .houston-menu__container {
+    &.hst-sidebar-has-topbar .hst-sidebar-container {
       top: ${TOPBAR_HEIGHT}px;
     }
 
     ${breakpoints.down('lg')} {
       width: 0;
 
-      & .houston-menu__container {
+      & .hst-sidebar-container {
         left: -${MENU_WIDTH}px;
         border: 0;
         opacity: 0;
         box-shadow: ${theme.shadow.level[1]};
       }
 
-      &.--visible .houston-menu__container {
+      &.hst-sidebar-visible .hst-sidebar-container {
         left: 0;
         opacity: 1;
       }

--- a/src/pages/ui-components/Layout/Topbar/Action/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Action/index.tsx
@@ -15,41 +15,35 @@ export interface ActionProps extends StyledProp {
 
 const Action: React.FC<ActionProps> = ({ active, icon, label, onClick, className }) => {
   return (
-    <div className={cx(className, { '--has-label': !!label })} onClick={onClick}>
+    <div className={cx(className, { 'hst-topbar-action-has-label': !!label })} onClick={onClick}>
       {!!label && (
-        <Button
-          startIcon={icon}
-          variant='text'
-          fullWidth
-          active={active}
-          className='houston-topbar-action__text-button'
-        >
+        <Button startIcon={icon} variant='text' fullWidth active={active} className='hst-topbar-action-text-button'>
           {label}
         </Button>
       )}
 
-      <IconButton className='houston-topbar-action__icon-button' active={active}>
+      <IconButton className='hst-topbar-action-icon-button' active={active}>
         {icon}
       </IconButton>
     </div>
   );
 };
 
-export default styled(Action, { label: 'houston-topbar-action' })(
+export default styled(Action, { label: 'hst-topbar-action' })(
   ({ theme }) => css`
-    & .houston-topbar-action__icon-button,
-    & .houston-topbar-action__text-button.--text {
+    & .hst-topbar-action-icon-button,
+    & .hst-topbar-action-text-button.--text {
       color: inherit;
     }
 
     ${theme.breakpoints.up('lg')} {
-      &.--has-label .houston-topbar-action__icon-button {
+      &.hst-topbar-action-has-label .hst-topbar-action-icon-button {
         display: none;
       }
     }
 
     ${theme.breakpoints.down('lg')} {
-      & .houston-topbar-action__text-button {
+      & .hst-topbar-action-text-button {
         display: none;
       }
     }

--- a/src/pages/ui-components/Layout/Topbar/Apps/Dropdown/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Apps/Dropdown/index.tsx
@@ -39,8 +39,13 @@ const AppsDropdown = React.memo<AppsDropdownProps>(
     }, [opened]);
 
     return (
-      <div className={cx(className, { '--opened': opened, '--expanded': expanded })}>
-        <div className='houston-topbar-apps-dropdown__header'>
+      <div
+        className={cx(className, {
+          'hst-topbar-apps-dropdown-opened': opened,
+          'hst-topbar-apps-dropdown-expanded': expanded
+        })}
+      >
+        <div className='hst-topbar-apps-dropdown-header'>
           <Typography weight='bold'>Lista de Apps</Typography>
 
           <IconButton onClick={toggleExpanded}>
@@ -48,9 +53,9 @@ const AppsDropdown = React.memo<AppsDropdownProps>(
           </IconButton>
         </div>
 
-        <div className='houston-topbar-apps-dropdown__list-apps'>
+        <div className='hst-topbar-apps-dropdown-list-apps'>
           {!applications?.length && (
-            <div className='houston-topbar-apps-dropdown__loader'>
+            <div className='hst-topbar-apps-dropdown-loader'>
               <Spinner size={40} />
             </div>
           )}
@@ -59,27 +64,23 @@ const AppsDropdown = React.memo<AppsDropdownProps>(
 
             return (
               <a
-                className={cx('houston-topbar-apps-dropdown__item', isCurrent && '--current')}
+                className={cx('hst-topbar-apps-dropdown-item', isCurrent && 'hst-topbar-apps-dropdown-current')}
                 key={app.application}
                 href={isCurrent ? undefined : app.url}
                 rel='noopener noreferrer'
                 target='_blank'
                 onClick={isCurrent ? onClose : undefined}
               >
-                <img src={app.icon} className='houston-topbar-apps-dropdown__icon' />
+                <img src={app.icon} className='hst-topbar-apps-dropdown-icon' />
 
                 <Typography
                   lineHeight='default'
-                  className='houston-topbar-apps-dropdown__label'
+                  className='hst-topbar-apps-dropdown-label'
                   size={expanded ? 'xs' : 'xxs'}
                 >
                   {app.label}
                 </Typography>
-                <Typography
-                  size='xs'
-                  color='neutralColor.low.medium'
-                  className='houston-topbar-apps-dropdown__description'
-                >
+                <Typography size='xs' color='neutralColor.low.medium' className='hst-topbar-apps-dropdown-description'>
                   {app.description}
                 </Typography>
               </a>
@@ -88,10 +89,10 @@ const AppsDropdown = React.memo<AppsDropdownProps>(
         </div>
 
         {!!applications?.length && (
-          <div className='houston-topbar-apps-dropdown__expand'>
+          <div className='hst-topbar-apps-dropdown-expand'>
             <Divider />
 
-            <div className='houston-topbar-apps-dropdown__expand-button'>
+            <div className='hst-topbar-apps-dropdown-expand-button'>
               <Button startIcon={<ExpandIcon />} variant='text' color='inherit' fullWidth onClick={toggleExpanded}>
                 Expandir
               </Button>
@@ -104,20 +105,19 @@ const AppsDropdown = React.memo<AppsDropdownProps>(
 );
 
 const descriptionAnimation = keyframes`
-0% { text-indent: -1000px; }
+  0% { text-indent: -1000px; }
   100% {  text-indent: 0px; }
 `;
 
-export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
+export default styled(AppsDropdown, { label: 'hst-topbar-apps-dropdown' })(
   ({ theme }) => css`
-    width: ${TOPBAR_DROPDOWN_WIDTH}px;
+    width: ${theme.pxToRem(TOPBAR_DROPDOWN_WIDTH)}rem;
     position: fixed;
-
-    background: #fff;
+    background: ${theme.neutralColor.high.pure};
     box-shadow: ${theme.shadow.level[2]};
-    top: ${TOPBAR_HEIGHT}px;
+    top: ${theme.pxToRem(TOPBAR_HEIGHT)}rem;
     left: ${theme.spacing.inline.nano};
-    border-radius: ${theme.border.radius.sm};
+    border-radius: 0 0 ${theme.border.radius.sm} ${theme.border.radius.sm};
     z-index: 105;
     transition: 0.15s ease-in-out;
     opacity: 0;
@@ -126,24 +126,26 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
     box-sizing: border-box;
     transform: scale(0.1);
     transform-origin: top left;
+    max-height: calc(100vh - ${theme.pxToRem(TOPBAR_HEIGHT)}rem);
+    overflow-y: auto;
 
     ${theme.breakpoints.down('sm')} {
       width: 100%;
       left: 0;
     }
 
-    &.--opened {
+    &.hst-topbar-apps-dropdown-opened {
       opacity: 1;
       transform: scale(1);
       visibility: visible;
       user-select: initial;
     }
 
-    .houston-topbar-apps-dropdown__header {
+    .hst-topbar-apps-dropdown-header {
       display: none;
     }
 
-    .houston-topbar-apps-dropdown__list-apps {
+    .hst-topbar-apps-dropdown-list-apps {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
       grid-gap: ${theme.spacing.nano};
@@ -152,7 +154,7 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
       box-sizing: border-box;
       padding: ${theme.spacing.xxxs};
 
-      .houston-topbar-apps-dropdown__loader {
+      .hst-topbar-apps-dropdown-loader {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -162,7 +164,7 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
         padding: ${theme.spacing.md};
       }
 
-      .houston-topbar-apps-dropdown__item {
+      .hst-topbar-apps-dropdown-item {
         width: 100%;
         text-align: center;
         transition: 0.15s ease-out;
@@ -172,13 +174,13 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
         padding: ${theme.spacing.xxxs} ${theme.spacing.nano};
         display: block;
 
-        .houston-topbar-apps-dropdown__icon {
-          max-width: 40px;
-          max-height: 40px;
+        .hst-topbar-apps-dropdown-icon {
+          max-width: ${theme.pxToRem(40)}rem;
+          max-height: ${theme.pxToRem(40)}rem;
           margin-bottom: ${theme.spacing.nano};
         }
 
-        .houston-topbar-apps-dropdown__description {
+        .hst-topbar-apps-dropdown-description {
           display: none;
           overflow: hidden;
 
@@ -189,7 +191,7 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
           }
         }
 
-        &.--current {
+        &.hst-topbar-apps-dropdown-current {
           background: rgba(0, 0, 0, 0.04);
         }
 
@@ -199,11 +201,11 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
       }
     }
 
-    .houston-topbar-apps-dropdown__expand .houston-topbar-apps-dropdown__expand-button {
+    .hst-topbar-apps-dropdown-expand .hst-topbar-apps-dropdown-expand-button {
       margin: ${theme.spacing.nano};
     }
 
-    &.--expanded {
+    &.hst-topbar-apps-dropdown-expanded {
       width: 100%;
       left: 0;
       height: calc(100% - ${TOPBAR_HEIGHT}px);
@@ -211,7 +213,7 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
       box-shadow: none;
       border-radius: 0;
 
-      .houston-topbar-apps-dropdown__header {
+      .hst-topbar-apps-dropdown-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -221,20 +223,20 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
           ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[3])};
       }
 
-      .houston-topbar-apps-dropdown__expand {
+      .hst-topbar-apps-dropdown-expand {
         display: none;
       }
 
-      .houston-topbar-apps-dropdown__list-apps {
+      .hst-topbar-apps-dropdown-list-apps {
         padding: 0;
         grid-template-columns: repeat(1, 1fr);
         grid-gap: 0;
 
-        .houston-topbar-apps-dropdown__item {
+        .hst-topbar-apps-dropdown-item {
           height: 100%;
           display: grid;
-          grid-template-columns: 25px 1fr;
-          grid-template-rows: 25px auto;
+          grid-template-columns: ${theme.pxToRem(25)}rem 1fr;
+          grid-template-rows: ${theme.pxToRem(25)}rem auto;
           grid-gap: ${theme.spacing.nano};
           text-align: left;
           padding: ${theme.spacing.xxs};
@@ -242,20 +244,20 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
             ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[3])};
           align-items: center;
 
-          .houston-topbar-apps-dropdown__icon {
-            max-width: 25px;
-            max-height: 25px;
+          .hst-topbar-apps-dropdown-icon {
+            max-width: ${theme.pxToRem(25)}rem;
+            max-height: ${theme.pxToRem(25)}rem;
             grid-column: 1;
             grid-row: 1;
             margin-bottom: 0;
           }
 
-          .houston-topbar-apps-dropdown__label {
+          .hst-topbar-apps-dropdown-label {
             grid-column: 2;
             grid-row: 1;
           }
 
-          .houston-topbar-apps-dropdown__description {
+          .hst-topbar-apps-dropdown-description {
             grid-column-start: 1;
             grid-column-end: 3;
             grid-row: 2;
@@ -268,24 +270,24 @@ export default styled(AppsDropdown, { label: 'houston-topbar-apps-dropdown' })(
           grid-template-columns: repeat(2, 1fr);
           grid-gap: ${theme.spacing.xxs};
 
-          .houston-topbar-apps-dropdown__item {
+          .hst-topbar-apps-dropdown-item {
             margin: auto;
             border: ${theme.border.width.xs} solid
               ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[3])};
-            grid-template-columns: 60px 1fr;
-            grid-template-rows: 20px auto;
+            grid-template-columns: ${theme.pxToRem(60)}rem 1fr;
+            grid-template-rows: ${theme.pxToRem(20)}rem auto;
             padding: ${theme.spacing.xxxs};
             grid-gap: ${theme.spacing.quarck};
             align-items: start;
 
-            .houston-topbar-apps-dropdown__icon {
+            .hst-topbar-apps-dropdown-icon {
               grid-row-start: 1;
               grid-row-end: 3;
-              max-width: 50px;
-              max-height: 50px;
+              max-width: ${theme.pxToRem(50)}rem;
+              max-height: ${theme.pxToRem(50)}rem;
             }
 
-            .houston-topbar-apps-dropdown__description {
+            .hst-topbar-apps-dropdown-description {
               grid-column-start: 2;
               grid-column-end: 2;
             }

--- a/src/pages/ui-components/Layout/Topbar/Apps/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Apps/index.tsx
@@ -63,7 +63,7 @@ const TopbarApps = React.memo<StyledProp>(({ className }) => {
   );
 });
 
-export default styled(TopbarApps, { label: 'houston-topbar-apps' })`
+export default styled(TopbarApps, { label: 'hst-topbar-apps' })`
   width: auto;
   position: relative;
   box-sizing: border-box;

--- a/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/Belt/index.tsx
@@ -40,10 +40,11 @@ const Belt = React.memo<StyledProp>(({ className }) => {
   }
 
   return (
-    <div className={cx(className, `--${beltClass}`)}>
-      <div className='houston-topbar-belt__badge'>
-        <BeltIcon size={25} className='houston-topbar-belt__icon' />
-        <Typography color='inherit' className='houston-topbar-belt__text' weight='semibold'>
+    <div className={cx(className, `hst-topbar-belt-color-${beltClass}`)}>
+      <div className='hst-topbar-belt-badge'>
+        <BeltIcon size={25} className='hst-topbar-belt-icon' />
+
+        <Typography color='inherit' className='hst-topbar-belt-text' weight='semibold'>
           {beltColor}
         </Typography>
       </div>
@@ -51,13 +52,13 @@ const Belt = React.memo<StyledProp>(({ className }) => {
   );
 });
 
-export default styled(Belt, { label: 'houston-topbar-belt' })(
+export default styled(Belt, { label: 'hst-topbar-belt' })(
   ({ theme }) => css`
     color: white;
     display: flex;
     align-items: center;
     padding: ${theme.spacing.squish.xxs};
-    border-radius: 20px;
+    border-radius: ${theme.border.radius.md};
     border-top-left-radius: 0;
     border-bottom-right-radius: 0;
     margin-right: ${theme.spacing.inline.xxs};
@@ -68,7 +69,7 @@ export default styled(Belt, { label: 'houston-topbar-belt' })(
     }
 
     ${theme.breakpoints.down('lg')} {
-      & .houston-topbar-belt__text {
+      & .hst-topbar-belt-text {
         display: none;
       }
     }
@@ -77,42 +78,42 @@ export default styled(Belt, { label: 'houston-topbar-belt' })(
       display: none;
     }
 
-    &.--white {
+    &.hst-topbar-belt-color-white {
       background-color: ${theme.beltColor.white};
       color: ${theme.beltColor.white};
     }
 
-    &.--red {
+    &.hst-topbar-belt-color-red {
       background-color: ${theme.beltColor.red};
       color: ${theme.beltColor.red};
     }
 
-    &.--orange {
+    &.hst-topbar-belt-color-orange {
       background-color: ${theme.beltColor.orange};
       color: ${theme.beltColor.orange};
     }
 
-    &.--green {
+    &.hst-topbar-belt-color-green {
       background-color: ${theme.beltColor.green};
       color: ${theme.beltColor.green};
     }
 
-    &.--black {
+    &.hst-topbar-belt-color-black {
       background-color: ${theme.beltColor.black};
       color: ${theme.beltColor.black};
     }
 
-    &.--golden {
+    &.hst-topbar-belt-color-golden {
       background-color: ${theme.beltColor.golden};
       color: ${theme.beltColor.golden};
     }
 
-    .houston-topbar-belt__badge {
+    .hst-topbar-belt-badge {
       color: white;
       display: flex;
       align-items: center;
 
-      & > .houston-topbar-belt__text {
+      & > .hst-topbar-belt-text {
         white-space: nowrap;
         text-transform: uppercase;
         font-style: italic;
@@ -120,8 +121,8 @@ export default styled(Belt, { label: 'houston-topbar-belt' })(
       }
     }
 
-    .houston-topbar-belt__icon {
-      min-width: 32px;
+    .hst-topbar-belt-icon {
+      min-width: ${theme.pxToRem(32)}rem;
       display: flex;
       align-items: center;
     }

--- a/src/pages/ui-components/Layout/Topbar/User/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/User/index.tsx
@@ -32,25 +32,28 @@ const User = React.memo<StyledProp>(({ className }) => {
 
   return (
     <>
-      <div ref={wrapperMenuUser} className={cx(className, { '--active': hasMenu && opened, '--has-menu': hasMenu })}>
-        <div className='houston-topbar-user__label'>
-          <div className='houston-topbar-user__default'>
+      <div
+        ref={wrapperMenuUser}
+        className={cx(className, { 'hst-topbar-user-active': hasMenu && opened, 'hst-topbar-user-has-menu': hasMenu })}
+      >
+        <div className='hst-topbar-user-label'>
+          <div className='hst-topbar-user-default'>
             <Button
               variant='text'
-              className='houston-topbar-user__button'
+              className='hst-topbar-user-button'
               startIcon={
                 <Avatar src={user.avatar} size='sm'>
                   {user.name}
                 </Avatar>
               }
-              endIcon={hasMenu && <IconChevronDown className='houston-topbar-user__menu-arrow' size='md' />}
+              endIcon={hasMenu && <IconChevronDown className='hst-topbar-user-menu-arrow' size='md' />}
               onClick={toogleOpened}
             >
               {user.name} {!!user.isSupport && '(Suporte)'}
             </Button>
           </div>
 
-          <div className='houston-topbar-user__mobile'>
+          <div className='hst-topbar-user-mobile'>
             <IconButton onClick={toogleOpened}>
               <Avatar src={user.avatar} size='sm'>
                 {user.name}
@@ -65,35 +68,35 @@ const User = React.memo<StyledProp>(({ className }) => {
   );
 });
 
-export default styled(User, { label: 'houston-topbar-user' })(
+export default styled(User, { label: 'hst-topbar-user' })(
   ({ theme }) => css`
     position: relative;
     z-index: 1100;
     margin-left: ${theme.spacing.inline.nano};
     pointer-events: none;
 
-    &.--has-menu {
+    &.hst-topbar-user-has-menu {
       pointer-events: all;
     }
 
-    & .houston-topbar-user__button.--text {
+    & .hst-topbar-user-button.--text {
       color: inherit;
     }
 
-    & .houston-topbar-user__menu-arrow {
+    & .hst-topbar-user-menu-arrow {
       display: block;
       transition: 0.15s ease-out;
     }
 
-    &.--active .houston-topbar-user__menu-arrow {
+    &.hst-topbar-user-active .hst-topbar-user-menu-arrow {
       transform: rotateX(180deg);
     }
 
-    & .houston-topbar-user__default {
+    & .hst-topbar-user-default {
       display: none;
       position: relative;
 
-      & .houston-topbar-user__support {
+      & .hst-topbar-user-support {
         position: absolute;
         bottom: 0;
         left: 57px;
@@ -103,11 +106,11 @@ export default styled(User, { label: 'houston-topbar-user' })(
     }
 
     ${theme.breakpoints.up('md')} {
-      & .houston-topbar-user__default {
+      & .hst-topbar-user-default {
         display: block;
       }
 
-      & .houston-topbar-user__mobile {
+      & .hst-topbar-user-mobile {
         display: none;
       }
     }

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/Divider/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/Divider/index.tsx
@@ -1,16 +1,5 @@
-import styled, { StyledProp, css } from '@eduzz/houston-styles';
-
 import Divider from '../../../../Divider';
 
-const UserMenuDivider: React.FC<StyledProp> = ({ className }) => {
-  return <Divider className={className} />;
-};
+const UserMenuDivider = () => <Divider />;
 
-export default styled(UserMenuDivider, { label: 'houston-topbar-user-menu-divider' })(
-  ({ theme }) => css`
-    &.--horizontal {
-      margin: ${theme.spacing.nano} -8px;
-      width: calc(100% + 16px);
-    }
-  `
-);
+export default UserMenuDivider;

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/Item/index.tsx
@@ -56,11 +56,11 @@ const UserMenuItem: React.FC<UserMenuItemProps> = ({
   return <>{content}</>;
 };
 
-export default styled(UserMenuItem, { label: 'houston-user-menu-item' })`
+export default styled(UserMenuItem, { label: 'hst-user-menu-item' })`
   justify-content: start;
   text-align: left;
 
-  &.--disabled {
+  &.hst-button-disabled {
     background-color: transparent;
   }
 `;

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/ItemGroup/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/ItemGroup/index.tsx
@@ -10,20 +10,21 @@ export interface UserMenuGroupProps extends StyledProp {
 const UserMenuGroup: React.FC<UserMenuGroupProps> = ({ label, className, children }) => {
   return (
     <div className={className}>
-      <Typography size='xxs' weight='semibold' className='houston-topbar-user-menu-group__label'>
+      <Typography size='xxs' weight='semibold' className='hst-topbar-user-menu-group-label'>
         {label}
       </Typography>
+
       {children}
     </div>
   );
 };
 
-export default styled(UserMenuGroup, { label: 'houston-topbar-user-menu-group' })(
+export default styled(UserMenuGroup, { label: 'hst-topbar-user-menu-group' })(
   ({ theme }) => css`
     display: flex;
     flex-direction: column;
 
-    & > .houston-topbar-user-menu-group__label {
+    & > .hst-topbar-user-menu-group-label {
       margin-top: ${theme.spacing.nano};
       padding: ${theme.spacing.squish.xxs};
       cursor: default;

--- a/src/pages/ui-components/Layout/Topbar/UserMenu/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/UserMenu/index.tsx
@@ -25,19 +25,19 @@ const UserMenu: React.FC<UserMenuProps> = ({ className, children }) => {
 
   return (
     <Portal target={container}>
-      <div className={cx(className, opened && '--opened')}>{children}</div>
+      <div className={cx(className, opened && 'hst-topbar-user-menu-opened')}>{children}</div>
     </Portal>
   );
 };
 
-export default styled(UserMenu, { label: 'houston-topbar-user-menu' })(
+export default styled(UserMenu, { label: 'hst-topbar-user-menu' })(
   ({ theme }) => css`
     display: flex;
     flex-direction: column;
     width: fit-content;
-    min-width: ${TOPBAR_MENU_MIN_WIDTH_IN_PX}px;
+    min-width: ${theme.pxToRem(TOPBAR_MENU_MIN_WIDTH_IN_PX)}rem;
     position: fixed;
-    top: ${TOPBAR_HEIGHT}px;
+    top: ${theme.pxToRem(TOPBAR_HEIGHT)}rem;
     right: ${theme.spacing.inline.nano};
     box-shadow: ${theme.shadow.level[2]};
     padding: ${theme.spacing.nano};
@@ -48,10 +48,10 @@ export default styled(UserMenu, { label: 'houston-topbar-user-menu' })(
     visibility: hidden;
     opacity: 0;
     user-select: none;
-    background: white;
+    background: ${theme.neutralColor.high.pure};
     border-radius: ${theme.border.radius.sm};
 
-    &.--opened {
+    &.hst-topbar-user-menu-opened {
       visibility: visible;
       opacity: 1;
       transform: scale(1);

--- a/src/pages/ui-components/Layout/Topbar/index.tsx
+++ b/src/pages/ui-components/Layout/Topbar/index.tsx
@@ -53,10 +53,10 @@ const Topbar = React.memo<TopbarProps>(
     }, [register]);
 
     React.useEffect(() => {
-      document.body.classList.add('houston-topbar-applied');
+      document.body.classList.add('hst-topbar-applied');
 
       return () => {
-        document.body.classList.remove('houston-topbar-applied');
+        document.body.classList.remove('hst-topbar-applied');
       };
     }, [theme]);
 
@@ -67,24 +67,24 @@ const Topbar = React.memo<TopbarProps>(
 
     return (
       <TopbarContext.Provider value={contextValue}>
-        <div className={cx(className, { '--black-mode': blackMode })}>
-          <header className='houston-topbar__header'>
-            <div className='houston-topbar__start'>
+        <div className={cx(className, { 'hst-topbar-black-mode': blackMode })}>
+          <header className='hst-topbar-header'>
+            <div className='hst-topbar-start'>
               <Action
-                className='houston-topbar__mobile-menu'
+                className='hst-topbar-mobile-menu'
                 icon={sidebarOpened ? <CancelIcon size={24} /> : <MenuLeft size={24} />}
                 onClick={sidebarToogleOpened}
               />
 
               <Apps />
 
-              <div className='houston-topbar__logo'>
+              <div className='hst-topbar-logo'>
                 <img
-                  className='houston-topbar__logo-default'
+                  className='hst-topbar-logo-default'
                   src={logo ?? `//eduzz-houston.s3.amazonaws.com/topbar/logos/eduzz${blackMode ? '' : '-colored'}.svg`}
                 />
                 <img
-                  className='houston-topbar__logo-mobile'
+                  className='hst-topbar-logo-mobile'
                   src={logoMobile ?? '//eduzz-houston.s3.amazonaws.com/topbar/logos/eduzz-mobile.svg'}
                 />
               </div>
@@ -93,7 +93,7 @@ const Topbar = React.memo<TopbarProps>(
                 <Typography
                   lineHeight='default'
                   color='inherit'
-                  className={cx('houston-topbar__tag', `--${user.tag}`)}
+                  className={cx('hst-topbar-tag', `hst-topbar-tag-${user.tag}`)}
                   size='xs'
                 >
                   {user.tag}
@@ -101,7 +101,7 @@ const Topbar = React.memo<TopbarProps>(
               )}
             </div>
 
-            <div className='houston-topbar__quick-access'>
+            <div className='hst-topbar-quick-access'>
               <Belt />
 
               {children}
@@ -114,11 +114,11 @@ const Topbar = React.memo<TopbarProps>(
   }
 );
 
-const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
+const TopbarStyled = styled(Topbar, { label: 'hst-topbar' })(
   ({ theme }) => css`
-    height: ${TOPBAR_HEIGHT}px;
+    height: ${theme.pxToRem(TOPBAR_HEIGHT)}rem;
 
-    & > .houston-topbar__header {
+    & > .hst-topbar-header {
       font-family: ${theme.font.family.base};
       background-color: white;
       color: ${theme.neutralColor.low.pure};
@@ -130,17 +130,17 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
       top: 0;
       left: 0;
       right: 0;
-      height: ${TOPBAR_HEIGHT}px;
+      height: ${theme.pxToRem(TOPBAR_HEIGHT)}rem;
       display: flex;
       justify-content: space-between;
       z-index: 105;
       transition: 0.15s ease-out;
 
-      & > .houston-topbar__start {
+      & > .hst-topbar-start {
         display: flex;
         align-items: center;
 
-        & .houston-topbar__mobile-menu {
+        & .hst-topbar-mobile-menu {
           cursor: pointer;
 
           ${breakpoints.up('lg')} {
@@ -148,7 +148,7 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
           }
         }
 
-        & .houston-topbar__logo {
+        & .hst-topbar-logo {
           height: 80%;
           width: auto;
           margin-inline: ${theme.spacing.inline.nano};
@@ -159,24 +159,24 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
             height: ${TOPBAR_HEIGHT}px;
           }
 
-          & > .houston-topbar__logo-mobile {
+          & > .hst-topbar-logo-mobile {
             display: none;
           }
 
           ${breakpoints.down('sm')} {
-            width: 32px;
+            width: ${theme.pxToRem(32)}rem;
 
-            & .houston-topbar__logo-default {
+            & .hst-topbar-logo-default {
               display: none;
             }
 
-            & .houston-topbar__logo-mobile {
+            & .hst-topbar-logo-mobile {
               display: block;
             }
           }
         }
 
-        .houston-topbar__tag {
+        .hst-topbar-tag {
           text-transform: capitalize;
           padding: ${theme.spacing.quarck};
           margin-top: 5px;
@@ -189,30 +189,30 @@ const TopbarStyled = styled(Topbar, { label: 'houston-topbar' })(
             display: block;
           }
 
-          &.--pro {
+          &.hst-topbar-tag-pro {
             border: ${theme.border.width.xs} solid ${theme.neutralColor.low.pure};
           }
 
-          &.--unity {
+          &.hst-topbar-tag-unity {
             border: ${theme.border.width.xs} solid ${theme.neutralColor.low.pure};
             background: ${theme.neutralColor.low.pure};
             color: white;
           }
 
-          &.--partner {
+          &.hst-topbar-tag-partner {
             background: ${theme.neutralColor.high.medium};
           }
         }
       }
 
-      & > .houston-topbar__quick-access {
+      & > .hst-topbar-quick-access {
         display: flex;
         align-items: center;
         justify-content: center;
       }
     }
 
-    &.--black-mode > .houston-topbar__header {
+    &.hst-topbar-black-mode > .hst-topbar-header {
       background-color: #272727;
       color: white;
     }

--- a/src/pages/ui-components/Link/index.mdx
+++ b/src/pages/ui-components/Link/index.mdx
@@ -67,10 +67,10 @@ import { NavLink } from 'react-router-dom';
 
 ### Link props
 
-| prop     | tipo                | obrigatório | padrão  | descrição |
-| -------- | ------------------- | ----------- | ------- | --------- |
-| children | `React.ReactNode`   | true        | -       |           |
-| as       | `React.ElementType` | `false`     | `a`     |           |
-| href     | `string`            | `false`     | -       |           |
-| showIcon | `boolean`           | `false`     | -       |           |
-| size     | xs, sm, md, inherit | `false`     | inherit |           |
+| prop     | tipo                | obrigatório | padrão    |
+| -------- | ------------------- | ----------- | --------- |
+| children | `React.ReactNode`   | `true`      | -         |
+| as       | `React.ElementType` | `false`     | `a`       |
+| href     | `string`            | `false`     | -         |
+| showIcon | `boolean`           | `false`     | -         |
+| size     | `LinkSizes`         | `false`     | `inherit` |

--- a/src/pages/ui-components/Link/index.tsx
+++ b/src/pages/ui-components/Link/index.tsx
@@ -1,6 +1,8 @@
 import ArrowRight from '@eduzz/houston-icons/ArrowRight';
 import styled, { css, cx, StyledProp } from '@eduzz/houston-styles';
 
+export type LinkSizes = 'xs' | 'sm' | 'md' | 'inherit';
+
 export interface LinkProps extends StyledProp, React.HTMLAttributes<HTMLAnchorElement> {
   /**
    * Allow to provide more props to the `as` Component
@@ -19,18 +21,18 @@ export interface LinkProps extends StyledProp, React.HTMLAttributes<HTMLAnchorEl
   /**
    * Defaults to 'inherit'
    */
-  size?: 'xs' | 'sm' | 'md' | 'inherit';
+  size?: LinkSizes;
   children: React.ReactNode;
 }
 
 const Link = ({ as: Tag = 'a', className, showIcon, size = 'inherit', children, ...rest }: LinkProps) => (
-  <Tag tabIndex={0} className={cx(className, `--link-size-${size}`)} {...rest}>
+  <Tag tabIndex={0} className={cx(className, `hst-link-size-${size}`)} {...rest}>
     {children}
     {showIcon && <ArrowRight size={size === 'md' ? 'md' : 'sm'} />}
   </Tag>
 );
 
-export default styled(Link, { label: 'houston-link' })(({ theme }) => {
+export default styled(Link, { label: 'hst-link' })(({ theme }) => {
   return css`
     all: unset;
     line-height: ${theme.line.height.default};
@@ -43,19 +45,19 @@ export default styled(Link, { label: 'houston-link' })(({ theme }) => {
     border-radius: ${theme.border.radius.xs};
     cursor: pointer;
 
-    &.--link-size-xs {
+    &.hst-link-size-xs {
       font-size: ${theme.font.size.xxs};
     }
 
-    &.--link-size-sm {
+    &.hst-link-size-sm {
       font-size: ${theme.font.size.xs};
     }
 
-    &.--link-size-md {
+    &.hst-link-size-md {
       font-size: ${theme.font.size.sm};
     }
 
-    &.--link-size-inherit {
+    &.hst-link-size-inherit {
       font-size: inherit;
     }
 

--- a/src/pages/ui-components/List/Item/index.tsx
+++ b/src/pages/ui-components/List/Item/index.tsx
@@ -21,7 +21,7 @@ const ListItem = ({ children, className, disabled, isActive, ...rest }: ListItem
       <li
         role='listitem'
         tabIndex={0}
-        className={cx(className, { '--disabled': disabled }, { '--active': isActive })}
+        className={cx(className, { 'hst-list-item-disabled': disabled }, { 'hst-list-item-active': isActive })}
         {...rest}
       >
         {children}
@@ -32,25 +32,26 @@ const ListItem = ({ children, className, disabled, isActive, ...rest }: ListItem
   );
 };
 
-export default styled(ListItem, { label: 'houston-list-item' })(({ theme }) => {
+export default styled(ListItem, { label: 'hst-list-item' })(({ theme }) => {
   return css`
     display: flex;
     align-items: center;
     line-height: 0;
     padding: ${theme.spacing.inset.xs};
 
-    &.--disabled {
+    &.hst-list-item-disabled {
       opacity: ${theme.opacity.level[6]};
       pointer-events: none;
+      user-select: none;
     }
 
-    &.--active {
+    &.hst-list-item-active {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[1])};
       transition: 0.5s background-color;
     }
 
-    :hover:not(.--disabled),
-    :focus:not(.--disabled) {
+    :hover:not(.hst-list-item-disabled),
+    :focus:not(.hst-list-item-disabled) {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       transition: 0.5s background-color;
     }

--- a/src/pages/ui-components/List/Left/index.tsx
+++ b/src/pages/ui-components/List/Left/index.tsx
@@ -8,7 +8,7 @@ export interface ListLeftProps extends StyledProp, React.HTMLAttributes<HTMLDivE
 
 const ListLeft = ({ children, ...rest }: ListLeftProps) => <div {...rest}>{children}</div>;
 
-export default styled(ListLeft, { label: 'houston-list-item-left' })(({ theme }) => {
+export default styled(ListLeft, { label: 'hst-list-item-left' })(({ theme }) => {
   return css`
     margin-right: ${theme.spacing.inline.xxxs};
   `;

--- a/src/pages/ui-components/List/List.tsx
+++ b/src/pages/ui-components/List/List.tsx
@@ -20,7 +20,7 @@ export interface ListProps extends StyledProp, React.HTMLAttributes<HTMLUListEle
 const List = ({ children, className, dividers = false, ...rest }: ListProps) => {
   return (
     <ListContextProvider dividers={dividers}>
-      <ul role='list' className={cx(className, { '--dividers': dividers })} {...rest}>
+      <ul role='list' className={cx(className, { 'hst-list-dividers': dividers })} {...rest}>
         {children}
       </ul>
     </ListContextProvider>
@@ -28,15 +28,15 @@ const List = ({ children, className, dividers = false, ...rest }: ListProps) => 
 };
 
 const ListWrapper = React.memo(
-  styled(List, { label: 'houston-list' })(() => {
-    return css`
-      &.--dividers {
+  styled(List, { label: 'hst-list' })(
+    () => css`
+      &.hst-list-dividers {
         hr:last-of-type {
           display: none;
         }
       }
-    `;
-  })
+    `
+  )
 );
 
 export default nestedComponent(ListWrapper, {

--- a/src/pages/ui-components/List/Right/index.tsx
+++ b/src/pages/ui-components/List/Right/index.tsx
@@ -8,7 +8,7 @@ export interface ListRightProps extends StyledProp, React.HTMLAttributes<HTMLDiv
 
 const ListRight = ({ children, ...rest }: ListRightProps) => <div {...rest}>{children}</div>;
 
-export default styled(ListRight, { label: 'houston-list-item-right' })(() => {
+export default styled(ListRight, { label: 'hst-list-item-right' })(() => {
   return css`
     margin-left: auto;
   `;

--- a/src/pages/ui-components/List/Text/index.tsx
+++ b/src/pages/ui-components/List/Text/index.tsx
@@ -14,7 +14,7 @@ export interface ListTitleProps
 }
 
 const ListText = ({ title, description, disableTypography = false, className, ...rest }: ListTitleProps) => (
-  <div className={cx('houston-list-item-text', className)} {...rest}>
+  <div className={cx('hst-list-item-text', className)} {...rest}>
     {!disableTypography ? (
       <Typography size='xs' weight='semibold' lineHeight='lg'>
         {title}

--- a/src/pages/ui-components/Loaders/Line/index.tsx
+++ b/src/pages/ui-components/Loaders/Line/index.tsx
@@ -14,7 +14,7 @@ const LineLoader = ({ className, mode = 'indeterminate', value }: LineLoaderProp
   const style = useMemo(() => (mode === 'determinate' ? { width: `${(value ?? 0) * 100}%` } : {}), [value, mode]);
 
   return (
-    <div className={cx(className, `--hts-line-loader-mode-${mode}`)}>
+    <div className={cx(className, `hst-line-loader-mode-${mode}`)}>
       <div style={style} />
     </div>
   );
@@ -32,7 +32,7 @@ const indeterminateShortAnimation = keyframes`
   100% { left: 107%; right: -8%; }
 `;
 
-export default styled(LineLoader, { label: 'houston-lineloader' })(
+export default styled(LineLoader, { label: 'hst-lineloader' })(
   ({ theme }) => css`
     position: relative;
     display: block;
@@ -45,7 +45,7 @@ export default styled(LineLoader, { label: 'houston-lineloader' })(
       background-color: ${theme.brandColor.primary.pure};
     }
 
-    &.--hts-line-loader-mode-indeterminate > div {
+    &.hst-line-loader-mode-indeterminate > div {
       &:before,
       &:after {
         content: '';
@@ -66,7 +66,7 @@ export default styled(LineLoader, { label: 'houston-lineloader' })(
       }
     }
 
-    &.--hts-line-loader-mode-determinate > div {
+    &.hst-line-loader-mode-determinate > div {
       position: absolute;
       top: 0;
       bottom: 0;

--- a/src/pages/ui-components/Loaders/Spinner/index.tsx
+++ b/src/pages/ui-components/Loaders/Spinner/index.tsx
@@ -31,7 +31,7 @@ const circleAnimation = (size: number) => keyframes`
   100% { stroke-dashoffset: ${(size / SIZE_BASE) * 187}; transform: rotate(450deg); }
 `;
 
-export default styled(Spinner, { label: 'houston-loader' })`
+export default styled(Spinner, { label: 'hst-loader' })`
   ${({ theme, color, size = SIZE_BASE }) => css`
     animation: ${rotationAnimation} 1.4s linear infinite;
     color: ${color === 'inherit' ? 'inherit' : getColorFallback(theme, color).pure};

--- a/src/pages/ui-components/Modal/Footer/index.tsx
+++ b/src/pages/ui-components/Modal/Footer/index.tsx
@@ -14,7 +14,7 @@ const ModalFooter = ({
   return (
     <footer className={cx(className, 'hst-modal-footer')} {...rest}>
       <Divider />
-      <div className='hst-modal-footer__wrapper'>{children}</div>
+      <div className='hst-modal-footer-wrapper'>{children}</div>
     </footer>
   );
 };
@@ -23,7 +23,7 @@ export default styled(ModalFooter, { label: 'hst-modal-footer' })`
   ${({ theme }) => css`
     border-radius: 0 0 ${theme.border.radius.sm} ${theme.border.radius.sm};
 
-    .hst-modal-footer__wrapper {
+    .hst-modal-footer-wrapper {
       padding: ${theme.spacing.squish.xs};
       display: flex;
       align-items: center;

--- a/src/pages/ui-components/Modal/Header/index.tsx
+++ b/src/pages/ui-components/Modal/Header/index.tsx
@@ -32,8 +32,8 @@ const ModalHeader = ({
   return (
     <header className={cx(className, 'hst-modal-header')} {...rest}>
       <div className='hst-modal-header__wrapper'>
-        <span className='hst-modal-header__title'>
-          {icon && <div className='hst-modal-header-title__icon'>{icon}</div>}
+        <span className='hst-modal-header-title'>
+          {icon && <div className='hst-modal-header-title-icon'>{icon}</div>}
 
           {!disableTypography ? (
             <Typography as='h6' size='sm'>
@@ -45,7 +45,7 @@ const ModalHeader = ({
         </span>
 
         {closeIcon && (
-          <IconButton className='hst-modal-header__close' aria-label='Fechar Modal' size='md' onClick={onClose}>
+          <IconButton className='hst-modal-header-close' aria-label='Fechar Modal' size='md' onClick={onClose}>
             <IconClose />
           </IconButton>
         )}
@@ -73,18 +73,18 @@ export default React.memo(styled(ModalHeader, { label: 'hst-modal-header' })`
         padding: ${theme.spacing.inset.xs};
       }
 
-      .hst-modal-header__title {
+      .hst-modal-header-title {
         display: flex;
         align-items: center;
 
-        .hst-modal-header-title__icon {
+        .hst-modal-header-title-icon {
           svg {
             margin-right: ${theme.spacing.inline.nano};
           }
         }
       }
 
-      .hst-modal-header__close {
+      .hst-modal-header-close {
         margin-left: ${theme.spacing.inline.xxs};
       }
     }

--- a/src/pages/ui-components/Modal/Modal.tsx
+++ b/src/pages/ui-components/Modal/Modal.tsx
@@ -67,13 +67,13 @@ const Modal = ({
       <Overlay visible={visible}>
         <ModalContextProvider value={contextValue}>
           {fullscreen && (
-            <div className={cx(className, '--hst-modal-fullscreen')} role='dialog' aria-modal {...rest}>
+            <div className={cx(className, 'hst-modal-fullscreen')} role='dialog' aria-modal {...rest}>
               {children}
             </div>
           )}
 
           {!fullscreen && (
-            <ModalBase className={cx(className, `--hst-modal-size-${size}`)} aria-modal {...rest}>
+            <ModalBase className={cx(className, `hst-modal-size-${size}`)} aria-modal {...rest}>
               {children}
             </ModalBase>
           )}
@@ -89,7 +89,7 @@ const ModalWrapper = styled(Modal, { label: 'hst-modal' })`
 
     Object.entries(modalSizesInPx).forEach(([size, value]) =>
       modifiers.push(css`
-        &.--hst-modal-size-${size} {
+        &.hst-modal-size-${size} {
           width: ${theme.pxToRem(value)}rem;
         }
       `)
@@ -109,7 +109,7 @@ const ModalWrapper = styled(Modal, { label: 'hst-modal' })`
         }
       }
 
-      &.--hst-modal-fullscreen {
+      &.hst-modal-fullscreen {
         width: 100vw;
         height: 100vh;
         max-height: 100vh;
@@ -129,7 +129,7 @@ const ModalWrapper = styled(Modal, { label: 'hst-modal' })`
         }
       }
 
-      &:not(.--hst-modal-fullscreen) > .hst-modal-header .hst-modal-header-title__icon {
+      &:not(.hst-modal-fullscreen) > .hst-modal-header .hst-modal-header-title__icon {
         display: none;
       }
 

--- a/src/pages/ui-components/Modal/__utils/ModalBase.tsx
+++ b/src/pages/ui-components/Modal/__utils/ModalBase.tsx
@@ -14,7 +14,7 @@ const ModalBase = ({ children, ...rest }: ModalBaseProps & StyledProp & React.HT
   );
 };
 
-export default styled(ModalBase)`
+export default styled(ModalBase, { label: 'hst-modal-base' })`
   ${({ theme }) => css`
     background-color: ${theme.neutralColor.high.pure};
     border-radius: ${theme.border.radius.sm};

--- a/src/pages/ui-components/Overlay/index.tsx
+++ b/src/pages/ui-components/Overlay/index.tsx
@@ -39,9 +39,9 @@ const Overlay = ({ className, visible, color = 'low', children, underTopbar, ...
       aria-hidden='true'
       tabIndex={-1}
       className={cx(className, {
-        '--hts-visible': visible,
-        '--hts-color-high': color === 'high',
-        '--hts-under-topbar': underTopbar
+        'hst-visible': visible,
+        'hst-color-high': color === 'high',
+        'hst-under-topbar': underTopbar
       })}
       {...rest}
     >
@@ -72,16 +72,16 @@ export default styled(Overlay, {
     backdrop-filter: blur(${theme.pxToRem(8)}rem);
     animation: ${fadeInAnimation} 200ms linear;
 
-    &.--hts-color-high {
+    &.hst-color-high {
       background: ${theme.hexToRgba(theme.neutralColor.high.pure, theme.opacity.level[6])};
     }
 
-    &.--hts-visible {
+    &.hst-visible {
       opacity: 1;
       visibility: visible;
     }
 
-    &.--hts-under-topbar {
+    &.hst-under-topbar {
       z-index: 104;
     }
   `

--- a/src/pages/ui-components/Pagination/Pages/index.tsx
+++ b/src/pages/ui-components/Pagination/Pages/index.tsx
@@ -160,7 +160,7 @@ const PaginationPages = ({
 
   return (
     <div className={className}>
-      <div className='hts-pagination__pages-buttons'>
+      <div className='hts-pagination-pages-buttons'>
         {pages?.map(({ page, onClick }) => (
           <Button
             key={page}
@@ -168,35 +168,35 @@ const PaginationPages = ({
             disabled={disabled}
             active={page === currentPage}
             onClick={onClick}
-            className='hts-pagination__pages-button'
+            className='hts-pagination-pages-button'
           >
             {typeof page === 'number' ? (
               page
             ) : (
               <>
-                <DotsHorizontalIcon className='--hts-hidden-hover' />
+                <DotsHorizontalIcon className='hst-pagination-pages-hidden-hover' />
                 {page === 'previous' ? (
-                  <ChevronLeft className='--hts-show-hover' />
+                  <ChevronLeft className='hst-pagination-pages-show-hover' />
                 ) : (
-                  <ChevronRight className='--hts-show-hover' />
+                  <ChevronRight className='hst-pagination-pages-show-hover' />
                 )}
               </>
             )}
           </Button>
         ))}
       </div>
-      <div className='hts-pagination__pages-mobile'>
+      <div className='hts-pagination-pages-mobile'>
         <Input
           size='sm'
           disabled={disabled}
           value={pageInput}
-          className='hts-pagination__pages-mobile-input'
+          className='hts-pagination-pages-mobile-input'
           onChange={handlePageInputChange as any}
           onKeyUp={handlePageInputChange}
           onBlur={handlePageInputChange as any}
         />
 
-        <Typography size='xs' weight='regular' className='hts-pagination__pages-mobile-text'>
+        <Typography size='xs' weight='regular' className='hts-pagination-pages-mobile-text'>
           de {maxPage}
         </Typography>
       </div>
@@ -204,44 +204,44 @@ const PaginationPages = ({
   );
 };
 
-export default styled(PaginationPages, { label: 'houston-pagination-pages' })(
+export default styled(PaginationPages, { label: 'hst-pagination-pages' })(
   ({ theme }) => css`
-    & .hts-pagination__pages-buttons {
+    & .hts-pagination-pages-buttons {
       align-items: center;
       display: flex;
       width: 100%;
 
-      & .hts-pagination__pages-button {
+      & .hts-pagination-pages-button {
         min-width: 0;
         font-weight: ${theme.font.weight.regular};
 
-        & .--hts-show-hover {
+        & .hst-pagination-pages-show-hover {
           display: none;
         }
 
         &:hover {
-          & .--hts-show-hover {
+          & .hst-pagination-pages-show-hover {
             display: initial;
           }
 
-          & .--hts-hidden-hover {
+          & .hst-pagination-pages-hidden-hover {
             display: none;
           }
         }
       }
     }
 
-    & .hts-pagination__pages-mobile {
+    & .hts-pagination-pages-mobile {
       display: none;
       align-items: center;
       justify-content: center;
       gap: ${theme.spacing.nano};
 
-      & .hts-pagination__pages-mobile-input {
+      & .hts-pagination-pages-mobile-input {
         width: 60px;
       }
 
-      & .hts-pagination__pages-mobile-text {
+      & .hts-pagination-pages-mobile-text {
         white-space: nowrap;
       }
     }
@@ -249,11 +249,11 @@ export default styled(PaginationPages, { label: 'houston-pagination-pages' })(
     ${theme.breakpoints.down('md')} {
       width: 100%;
 
-      & .hts-pagination__pages-buttons {
+      & .hts-pagination-pages-buttons {
         display: none;
       }
 
-      & .hts-pagination__pages-mobile {
+      & .hts-pagination-pages-mobile {
         display: flex;
       }
     }

--- a/src/pages/ui-components/Pagination/index.tsx
+++ b/src/pages/ui-components/Pagination/index.tsx
@@ -97,7 +97,7 @@ const Pagination = ({
   );
 };
 
-export default styled(React.memo(Pagination), { label: 'houston-pagination' })(
+export default styled(React.memo(Pagination), { label: 'hst-pagination' })(
   ({ theme }) => css`
     display: flex;
     flex-direction: row;

--- a/src/pages/ui-components/Popover/Root.tsx
+++ b/src/pages/ui-components/Popover/Root.tsx
@@ -33,7 +33,7 @@ const PopoverRoot = ({ children }: PopoverProps) => {
 
   React.useEffect(() => {
     if (!state.opened) {
-      popoverContent.current?.classList?.remove('--opened');
+      popoverContent.current?.classList?.remove('hst-popover-opened');
       return undefined;
     }
 
@@ -55,10 +55,10 @@ const PopoverRoot = ({ children }: PopoverProps) => {
       ]
     });
 
-    popoverContent.current?.classList?.add('--opened');
+    popoverContent.current?.classList?.add('hst-popover-opened');
 
     return () => {
-      popoverContent.current?.classList?.remove('--opened');
+      popoverContent.current?.classList?.remove('hst-popover-opened');
       setTimeout(() => instance.destroy(), 100);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/ui-components/Popover/index.tsx
+++ b/src/pages/ui-components/Popover/index.tsx
@@ -62,8 +62,10 @@ const Popover = React.forwardRef<PopoverRef, PopoverProps>(
     );
 
     return (
-      <div id={id} ref={contentRef} className={cx(className, 'popover')}>
-        <div className={cx('__container', { [`--${variant}`]: !!variant })}>{render && children}</div>
+      <div id={id} ref={contentRef} className={cx(className, 'hst-popover')}>
+        <div className={cx('hst-popover-container', { [`hst-popover-variant-${variant}`]: !!variant })}>
+          {render && children}
+        </div>
       </div>
     );
   }
@@ -79,7 +81,7 @@ const hideAnimation = keyframes`
   100% { transform: scale(0.9); opacity: 0; }
 `;
 
-export default styled(Popover, { label: 'houston-popover' })(
+export default styled(Popover, { label: 'hst-popover' })(
   ({ theme }) => css`
     box-sizing: border-box;
     max-width: 100vw;
@@ -89,12 +91,12 @@ export default styled(Popover, { label: 'houston-popover' })(
     top: calc(100vh * -1000);
     left: calc(100vh * -1000);
 
-    & > .__container {
+    & > .hst-popover-container {
       width: 100%;
       max-height: 50vh;
       overflow-y: auto;
       overflow-x: hidden;
-      background-color: white;
+      background-color: ${theme.neutralColor.high.pure};
       box-shadow: ${theme.shadow.level[3]};
       border-radius: ${theme.border.radius.sm};
       box-sizing: border-box;
@@ -103,16 +105,16 @@ export default styled(Popover, { label: 'houston-popover' })(
       animation-name: ${hideAnimation};
       animation-fill-mode: forwards;
 
-      &.--tooltip {
+      &.hst-popover-variant-tooltip {
         overflow-y: unset;
         overflow-x: unset;
       }
     }
 
-    &.--opened {
+    &.hst-popover-opened {
       pointer-events: auto;
 
-      & > .__container {
+      & > .hst-popover-container {
         animation-name: ${showAnimation};
       }
     }

--- a/src/pages/ui-components/Portal/index.tsx
+++ b/src/pages/ui-components/Portal/index.tsx
@@ -13,6 +13,7 @@ export interface PortalProps {
 function createWrapper(id: string) {
   const element = document.createElement('div');
   element.setAttribute('id', id);
+  element.classList.add('hst-portal');
   document.body.appendChild(element);
   return element;
 }

--- a/src/pages/ui-components/Progress/Bar/index.tsx
+++ b/src/pages/ui-components/Progress/Bar/index.tsx
@@ -8,9 +8,9 @@ export interface ProgressBarProps {
 
 const ProgressBar = ({ className, value, min, max }: ProgressBarProps & StyledProp) => {
   return (
-    <div className={cx(className, 'hst-progress__bar')}>
+    <div className={cx(className, 'hst-progress-bar')}>
       <span
-        className='hst-progress-bar__filled'
+        className='hst-progress-bar-filled'
         style={{ width: `${value > 0 ? value : 0}%` }}
         aria-valuemax={max}
         aria-valuemin={min}
@@ -28,7 +28,7 @@ const ProgressBarWrapper = styled(ProgressBar, { label: 'hst-progress-bar' })`
     border-radius: ${theme.border.radius.pill};
     overflow: hidden;
 
-    & > .hst-progress-bar__filled {
+    & > .hst-progress-bar-filled {
       height: 100%;
       display: block;
       background-color: ${theme.feedbackColor.positive.pure};

--- a/src/pages/ui-components/Progress/index.tsx
+++ b/src/pages/ui-components/Progress/index.tsx
@@ -81,11 +81,11 @@ const Progress = ({
   };
 
   return (
-    <div className={cx(className, `--hst-progress-size-${size}`, { '--hst-progress-has-label': hasLabel })} {...rest}>
+    <div className={cx(className, `hst-progress-size-${size}`, { 'hst-progress-has-label': hasLabel })} {...rest}>
       {hasLabelTop && (
         <div
-          className={cx('hst-progress-label__top', {
-            '--hst-progress-label-top-right': !!!labelTopStart && !!labelTopEnd
+          className={cx('hst-progress-label-top', {
+            'hst-progress-label-top-right': !!!labelTopStart && !!labelTopEnd
           })}
         >
           {!!labelTopStart && <Typography {...typographyLabelProps}>{labelTopStart}</Typography>}
@@ -93,9 +93,9 @@ const Progress = ({
         </div>
       )}
 
-      <div className='hst-progress__wrapper'>
+      <div className='hst-progress-wrapper'>
         {showInfo && (
-          <div className={cx('hst-progress__percent', { '--hst-progress-percent-right': infoPosition === 'right' })}>
+          <div className={cx('hst-progress-percent', { 'hst-progress-percent-right': infoPosition === 'right' })}>
             <Typography size='xxs' lineHeight='xs'>
               {percentage}
               {format === 'percentage' && '%'}
@@ -108,8 +108,8 @@ const Progress = ({
 
       {hasLabelBottom && (
         <div
-          className={cx('hst-progress-label__bottom', {
-            '--hst-progress-label-bottom-right': !!!labelBottomStart && !!labelBottomEnd
+          className={cx('hst-progress-label-bottom', {
+            'hst-progress-label-bottom-right': !!!labelBottomStart && !!labelBottomEnd
           })}
         >
           {!!labelBottomStart && <Typography {...typographyLabelProps}>{labelBottomStart}</Typography>}
@@ -124,45 +124,45 @@ const ProgressWrapper = styled(Progress, { label: 'hst-progress' })`
   ${({ theme }) => css`
     min-width: ${theme.pxToRem(MIN_WIDTH_DEFAULT)}rem;
 
-    &.--hst-progress-size-sm {
-      & > .hst-progress__wrapper {
-        & > .hst-progress__bar {
+    &.hst-progress-size-sm {
+      & > .hst-progress-wrapper {
+        & > .hst-progress-bar {
           height: ${theme.pxToRem(HEIGHT_BAR_SMALL)}rem;
         }
       }
     }
 
-    &.--hst-progress-size-md {
-      & > .hst-progress__wrapper {
-        & > .hst-progress__bar {
+    &.hst-progress-size-md {
+      & > .hst-progress-wrapper {
+        & > .hst-progress-bar {
           height: ${theme.pxToRem(HEIGHT_BAR_DEFAULT)}rem;
         }
       }
     }
 
-    &.--hst-progress-has-label {
+    &.hst-progress-has-label {
       min-width: ${theme.pxToRem(MIN_WIDTH_WHEN_LABEL)}rem;
     }
 
-    & > .hst-progress-label__top {
+    & > .hst-progress-label-top {
       display: flex;
       justify-content: space-between;
       margin-bottom: ${theme.spacing.inline.quarck};
 
-      &.--hst-progress-label-top-right {
+      &.hst-progress-label-top-right {
         justify-content: flex-end;
       }
     }
 
-    & > .hst-progress__wrapper {
+    & > .hst-progress-wrapper {
       display: flex;
       align-items: center;
 
-      & > .hst-progress__percent {
+      & > .hst-progress-percent {
         order: 0;
         margin-right: ${theme.spacing.inline.quarck};
 
-        &.--hst-progress-percent-right {
+        &.hst-progress-percent-right {
           order: 1;
           margin-left: ${theme.spacing.inline.quarck};
           margin-right: 0;
@@ -170,12 +170,12 @@ const ProgressWrapper = styled(Progress, { label: 'hst-progress' })`
       }
     }
 
-    & > .hst-progress-label__bottom {
+    & > .hst-progress-label-bottom {
       display: flex;
       justify-content: space-between;
       margin-top: ${theme.spacing.inline.quarck};
 
-      &.--hst-progress-label-bottom-right {
+      &.hst-progress-label-bottom-right {
         justify-content: flex-end;
       }
     }

--- a/src/pages/ui-components/Showcase/ControlDots/index.tsx
+++ b/src/pages/ui-components/Showcase/ControlDots/index.tsx
@@ -11,7 +11,9 @@ const ControlDots = ({ className }: StyledProp) => {
   const controlDots = useContextSelector(ShowcaseContext, context => context.controlDots);
   const totalSteps = useContextSelector(ShowcaseContext, context => context.totalSteps);
 
-  if (!controlDots) return null;
+  if (!controlDots) {
+    return null;
+  }
 
   const dots = Array(totalSteps).fill(0);
 
@@ -20,17 +22,22 @@ const ControlDots = ({ className }: StyledProp) => {
       {dots.map((_, index) => {
         const activeDot = currentStep - 1 === index;
 
-        return <span key={`dot-${index}`} className={cx('hst-dots', `${activeDot && '--hst-dots-active'}`)} />;
+        return (
+          <span
+            key={`dot-${index}`}
+            className={cx('hst-showcase-control-dots', `${activeDot && 'hst-showcase-control-dots-active'}`)}
+          />
+        );
       })}
     </div>
   );
 };
 
-export default styled(ControlDots, { label: 'hst-control-dots' })`
+export default styled(ControlDots, { label: 'hst-showcase-control-dots' })`
   ${({ theme }) => css`
     padding: ${theme.spacing.inset.sm};
 
-    & .hst-dots {
+    & .hst-showcase-control-dots {
       height: ${theme.pxToRem(DOTS_DIMENSION_SIZE)}rem;
       width: ${theme.pxToRem(DOTS_DIMENSION_SIZE)}rem;
       margin-right: ${theme.pxToRem(DOTS_DIMENSION_SIZE)}rem;
@@ -40,7 +47,7 @@ export default styled(ControlDots, { label: 'hst-control-dots' })`
       display: inline-block;
     }
 
-    & .--hst-dots-active {
+    & .hst-showcase-control-dots-active {
       background-color: ${theme.brandColor.primary.pure};
       border: none;
     }

--- a/src/pages/ui-components/Showcase/Image/index.tsx
+++ b/src/pages/ui-components/Showcase/Image/index.tsx
@@ -5,7 +5,7 @@ export interface ShowcaseImageProps {
   alt: string;
 }
 
-const IMAGE_HEIGHT = 235;
+const IMAGE_CONTAINER = 235;
 
 const Image = ({ src, alt, ...rest }: ShowcaseImageProps & React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
   return (
@@ -18,7 +18,7 @@ const Image = ({ src, alt, ...rest }: ShowcaseImageProps & React.HTMLAttributes<
 export default styled(Image, { label: 'hst-showcase-image' })`
   ${({ theme }) => css`
     width: 100%;
-    height: ${theme.pxToRem(IMAGE_HEIGHT)}rem;
+    height: ${theme.pxToRem(IMAGE_CONTAINER)}rem;
     border-radius: ${theme.border.radius.sm} ${theme.border.radius.sm} 0 0;
     display: flex;
     justify-content: center;

--- a/src/pages/ui-components/Showcase/Text/index.tsx
+++ b/src/pages/ui-components/Showcase/Text/index.tsx
@@ -1,7 +1,19 @@
 import styled, { css, StyledProp } from '@eduzz/houston-styles';
 import Paragraph from '@eduzz/houston-ui/Typography/Paragraph';
 
-const Text = ({ children, className }: React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
+export interface ShowcaseTextProps {
+  disableTypography?: boolean;
+}
+
+const Text = ({
+  children,
+  className,
+  disableTypography
+}: ShowcaseTextProps & React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
+  if (disableTypography) {
+    return <>{children}</>;
+  }
+
   return (
     <Paragraph className={className} size='sm' color='neutralColor.low.medium'>
       {children}

--- a/src/pages/ui-components/Showcase/Title/index.tsx
+++ b/src/pages/ui-components/Showcase/Title/index.tsx
@@ -1,7 +1,19 @@
 import styled, { css, StyledProp } from '@eduzz/houston-styles';
 import Heading from '@eduzz/houston-ui/Typography/Heading';
 
-const Title = ({ children, className }: React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
+export interface ShowcaseTitleProps {
+  disableTypography?: boolean;
+}
+
+const Title = ({
+  children,
+  className,
+  disableTypography
+}: ShowcaseTitleProps & React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
+  if (disableTypography) {
+    return <>{children}</>;
+  }
+
   return (
     <Heading size='sm' as='h6' className={className} color='neutralColor.low.dark'>
       {children}
@@ -12,7 +24,6 @@ const Title = ({ children, className }: React.HTMLAttributes<HTMLDivElement> & S
 export default styled(Title, { label: 'hst-showcase-title' })`
   ${({ theme }) => css`
     padding: ${theme.spacing.inset.sm};
-
     padding-bottom: 0;
   `}
 `;

--- a/src/pages/ui-components/Showcase/index.mdx
+++ b/src/pages/ui-components/Showcase/index.mdx
@@ -130,3 +130,15 @@ import Showcase from '@eduzz/houston-ui/Showcase';
 | ---- | -------- | ----------- | ------ | --------- |
 | src  | `string` | `true`      | -      | -         |
 | alt  | `string` | `true`      | -      | -         |
+
+### Showcase.Title
+
+| prop              | tipo      | obrigatório | padrão  | descrição                                                  |
+| ----------------- | --------- | ----------- | ------- | ---------------------------------------------------------- |
+| disableTypography | `boolean` | `false`     | `false` | Se `true`, o componente `Typography` não será renderizado. |
+
+### Showcase.Text
+
+| prop              | tipo      | obrigatório | padrão  | descrição                                                  |
+| ----------------- | --------- | ----------- | ------- | ---------------------------------------------------------- |
+| disableTypography | `boolean` | `false`     | `false` | Se `true`, o componente `Typography` não será renderizado. |

--- a/src/pages/ui-components/Showcase/index.tsx
+++ b/src/pages/ui-components/Showcase/index.tsx
@@ -35,7 +35,9 @@ const Showcase = ({
   controlDots,
   ...rest
 }: ShowcaseProps & React.HTMLAttributes<HTMLDivElement> & StyledProp) => {
-  if (!open) return null;
+  if (!open) {
+    return null;
+  }
 
   const [showcaseContent] = children as React.ReactElement[];
 
@@ -61,12 +63,12 @@ const Showcase = ({
   );
 };
 
-const StyledShowcase = styled(Showcase, { label: 'houston-showcase' })`
+const StyledShowcase = styled(Showcase, { label: 'hst-showcase' })`
   ${({ theme, widthSize }) => {
     return css`
       width: ${theme.pxToRem(widthSize - OFFSET)}rem;
       max-width: ${theme.pxToRem(MAX_SHOWCASE_WIDTH)}rem;
-      max-height: 90%;
+      max-height: 90vw;
       overflow-x: hidden;
       box-shadow: none;
     `;

--- a/src/pages/ui-components/Table/Action/index.tsx
+++ b/src/pages/ui-components/Table/Action/index.tsx
@@ -82,7 +82,7 @@ export default styled(React.memo(TableActionOption))`
   text-align: left;
   border-radius: 0;
 
-  &.--disabled {
+  &.hst-button-disabled {
     background-color: transparent;
   }
 `;

--- a/src/pages/ui-components/Table/Body/index.tsx
+++ b/src/pages/ui-components/Table/Body/index.tsx
@@ -37,7 +37,11 @@ const TableBody = ({ children }: TableBodyProps) => {
         <tr>
           <td align='center' colSpan={1000}>
             <LineLoader />
-            <div className='hts-table__loading-text'>{loadingText}</div>
+            <div className='hts-table-loading-text'>
+              <Typography weight='regular' lineHeight='xl' className='hst-table-body-text'>
+                {loadingText}
+              </Typography>
+            </div>
           </td>
         </tr>
       </tbody>
@@ -49,7 +53,7 @@ const TableBody = ({ children }: TableBodyProps) => {
       <tbody>
         <tr>
           <TableCell align='center' colSpan={1000}>
-            <Typography marginBottom='xxxs' weight='regular' lineHeight='xl' className='__text'>
+            <Typography marginBottom='xxxs' weight='regular' lineHeight='xl' className='hst-table-body-text'>
               {errorMessage}
             </Typography>
 
@@ -69,7 +73,9 @@ const TableBody = ({ children }: TableBodyProps) => {
       <tbody>
         <tr>
           <TableCell align='center' colSpan={1000}>
-            {emptyText}
+            <Typography weight='regular' lineHeight='xl' className='hst-table-body-text'>
+              {emptyText}
+            </Typography>
           </TableCell>
         </tr>
       </tbody>

--- a/src/pages/ui-components/Table/Cell/index.tsx
+++ b/src/pages/ui-components/Table/Cell/index.tsx
@@ -8,7 +8,7 @@ export interface TableCellProps extends StyledProp, React.TdHTMLAttributes<HTMLT
 
 const TableCell = ({ children, className, ...props }: TableCellProps) => {
   return (
-    <td {...props} className={cx(className, 'hts-table__cell')}>
+    <td {...props} className={cx(className, 'hts-table-cell')}>
       {children}
     </td>
   );

--- a/src/pages/ui-components/Table/Collapse/index.tsx
+++ b/src/pages/ui-components/Table/Collapse/index.tsx
@@ -46,10 +46,10 @@ const CollapseContent = ({
       <td
         colSpan={1000}
         className={cx(
-          'hts-table__collapse',
-          visible && '--hts-opened',
-          disableBackground && '--hts-no-background',
-          disabledPadding && '--hts-no-padding'
+          'hts-table-collapse',
+          visible && 'hts-table-collapse-opened',
+          disableBackground && 'hts-table-collapse-no-background',
+          disabledPadding && 'hts-table-collapse-no-padding'
         )}
       >
         <Collapse

--- a/src/pages/ui-components/Table/Column/SortLabel/index.tsx
+++ b/src/pages/ui-components/Table/Column/SortLabel/index.tsx
@@ -19,12 +19,12 @@ const SortLabel: React.FC<SortLabelProps> = ({ children, sortable, active, direc
 
   return (
     <div
-      className={cx('hts-table__column-sort', { '--hts-sort-rev': direction === 'desc' })}
+      className={cx('hts-table-column-sort', { 'hts-table-column-sort-rev': direction === 'desc' })}
       onClick={disabled ? undefined : onClick}
     >
       {children}
 
-      {active && <IconArrowUp className='hts-table__column-sort-icon' />}
+      {active && <IconArrowUp className='hts-table-column-sort-icon' />}
     </div>
   );
 };

--- a/src/pages/ui-components/Table/Column/index.tsx
+++ b/src/pages/ui-components/Table/Column/index.tsx
@@ -31,7 +31,7 @@ const TableColumn = ({ sortableField, children, className, ...rest }: TableColum
   }, [onSort, sortableField, isSorted, sortDirection]);
 
   return (
-    <th className={cx(className, 'hts-table__column', { '--hts-disabled': loading })} {...rest}>
+    <th className={cx(className, 'hts-table-column', { 'hts-table-column-disabled': loading })} {...rest}>
       <SortLabel
         sortable={!!sortableField}
         active={isSorted}

--- a/src/pages/ui-components/Table/Header/index.tsx
+++ b/src/pages/ui-components/Table/Header/index.tsx
@@ -27,13 +27,13 @@ const TableHeader = ({ children, disabledActionsColumn, columnActionTitle, ...co
 
   return (
     <TableHeaderContext.Provider value={contextValue}>
-      <thead className={columnActionHidden ? '--hts-action-column-hidden' : undefined}>
+      <thead className={columnActionHidden ? 'hst-table-action-column-hidden' : undefined}>
         <tr>
           {children}
 
           {!disabledActionsColumn && (
             <TableColumn
-              className={columnActionHidden ? '--hts-hidden' : undefined}
+              className={columnActionHidden ? 'hst-table-hidden' : undefined}
               width={hasActions && hasCollapse ? 100 : hasActions || hasCollapse ? 75 : 0}
               align='right'
             >

--- a/src/pages/ui-components/Table/Pagination/index.tsx
+++ b/src/pages/ui-components/Table/Pagination/index.tsx
@@ -18,7 +18,7 @@ const TablePagination = ({ disabled, ...props }: TablePaginationProps) => {
         total={total ?? 0}
         mode='table'
         disabled={disabled ?? loading}
-        className='hts-table__pagination'
+        className='hts-table-pagination'
       />
     </Portal>
   );

--- a/src/pages/ui-components/Table/Row/index.tsx
+++ b/src/pages/ui-components/Table/Row/index.tsx
@@ -29,9 +29,10 @@ const TableRow = ({ data, index, children, className, ...props }: TableRowProps)
 
   const [portals] = React.useState(() => {
     const ref = ++actionIncremeter;
+
     return {
-      actions: `hts-table__row-actions-${ref}`,
-      collapse: `hts-table__row-collapse-${ref}`
+      actions: `hts-table-row-actions-${ref}`,
+      collapse: `hts-table-row-collapse-${ref}`
     };
   });
 
@@ -83,10 +84,10 @@ const TableRow = ({ data, index, children, className, ...props }: TableRowProps)
 
         <td
           align='right'
-          className={cx('hts-table__cell-action', !hasActionInRows && !hasCollapseInRows && '--hts-hidden')}
+          className={cx('hts-table-cell-action', !hasActionInRows && !hasCollapseInRows && 'hst-table-hidden')}
         >
           <Popover {...popoverProps} placement='bottom-end' keepMounted>
-            <div id={portals.actions} className='hts-table__cell-action-menu' />
+            <div id={portals.actions} className='hts-table-cell-action-menu' />
           </Popover>
 
           {hasActions && (
@@ -97,7 +98,9 @@ const TableRow = ({ data, index, children, className, ...props }: TableRowProps)
 
           {hasCollapse && (
             <IconButton onClick={toogleShowCollapse}>
-              <IconChevronDown className={cx('hts-table__cell-collapse-arrow', showCollapse && '--hts-active')} />
+              <IconChevronDown
+                className={cx('hts-table-cell-collapse-arrow', showCollapse && 'hts-table-cell-collapse-arrow-active')}
+              />
             </IconButton>
           )}
         </td>

--- a/src/pages/ui-components/Table/Table.tsx
+++ b/src/pages/ui-components/Table/Table.tsx
@@ -42,7 +42,7 @@ const Table = ({
 }: TableProps) => {
   const scroller = React.useRef<HTMLDivElement>(null);
 
-  const [paginationPortal] = React.useState(() => `hts-table__pagination-${++tablePortalIncremeter}`);
+  const [paginationPortal] = React.useState(() => `hts-table-pagination-${++tablePortalIncremeter}`);
 
   const [rows, setRows] = React.useState<TableRow[]>([]);
   const registerRow = React.useCallback((row: Omit<TableRow, 'key'>) => {
@@ -109,8 +109,8 @@ const Table = ({
       if (apply !== previousState) {
         previousState = apply;
         apply
-          ? scroller.current?.parentElement?.classList.add('--hts-scrollable')
-          : scroller.current?.parentElement?.classList.remove('--hts-scrollable');
+          ? scroller.current?.parentElement?.classList.add('hst-table-scrollable')
+          : scroller.current?.parentElement?.classList.remove('hst-table-scrollable');
       }
 
       setTimeout(() => (wait = false), 200);
@@ -127,9 +127,9 @@ const Table = ({
 
   return (
     <TableContext.Provider value={contextValue}>
-      <div className={cx(className, `--hts-table-size-${size}`)}>
-        <div className='hts-table__scroller-shadow'>
-          <div className='hts-table__scroller'>
+      <div className={cx(className, `hst-table-size-${size}`)}>
+        <div className='hts-table-scroller-shadow'>
+          <div className='hts-table-scroller'>
             <div ref={scroller}>
               <table {...tableProps} style={{ minWidth }}>
                 {children}
@@ -143,13 +143,13 @@ const Table = ({
   );
 };
 
-export default styled(React.memo(Table), { label: 'houston-table' })(
+export default styled(React.memo(Table), { label: 'hst-table' })(
   ({ theme }) => css`
-    & > .hts-table__scroller-shadow {
+    & > .hts-table-scroller-shadow {
       position: relative;
       overflow: hidden;
 
-      & > .hts-table__scroller {
+      & > .hts-table-scroller {
         &:before {
           content: ' ';
           position: absolute;
@@ -160,7 +160,7 @@ export default styled(React.memo(Table), { label: 'houston-table' })(
           transition: 0.15s;
         }
 
-        &.--hts-scrollable:before {
+        &.hst-table-scrollable:before {
           box-shadow: ${theme.shadow.level[2]};
         }
 
@@ -169,7 +169,7 @@ export default styled(React.memo(Table), { label: 'houston-table' })(
         }
       }
 
-      & > .hts-table__scroller > div > table {
+      & > .hts-table-scroller > div > table {
         width: 100%;
         border-spacing: 0px;
 
@@ -185,121 +185,121 @@ export default styled(React.memo(Table), { label: 'houston-table' })(
               border-top-right-radius: ${theme.border.radius.sm};
             }
 
-            &.hts-table__column {
+            &.hts-table-column {
               font-weight: ${theme.font.weight.bold};
 
               &:not([align]) {
                 text-align: left;
               }
 
-              & .hts-table__column-sort {
+              & .hts-table-column-sort {
                 display: inline-flex;
                 align-items: center;
                 cursor: pointer;
 
-                & > .hts-table__column-sort-icon {
+                & > .hts-table-column-sort-icon {
                   transition: 0.2s linear;
                 }
 
-                &.--hts-sort-rev > .hts-table__column-sort-icon {
+                &.hts-table-column-sort-rev > .hts-table-column-sort-icon {
                   transform: rotateX(-180deg);
                 }
               }
 
-              &.--hts-disabled {
+              &.hts-table-column-disabled {
                 color: ${theme.neutralColor.low.light};
 
-                & .hts-table__column-sort {
+                & .hts-table-column-sort {
                   cursor: not-allowed;
                 }
               }
             }
           }
 
-          &.--hts-action-column-hidden > tr > th:nth-last-of-type(2) {
+          &.hst-table-action-column-hidden > tr > th:nth-last-of-type(2) {
             border-top-right-radius: ${theme.border.radius.sm};
           }
         }
 
-        & > tbody > tr > td.hts-table__cell {
+        & > tbody > tr > td.hts-table-cell {
           font-weight: ${theme.font.weight.regular};
         }
 
-        & > thead > tr > th.hts-table__column,
-        & > tbody > tr > td.hts-table__cell,
-        & > tbody > tr > td > .hts-table__loading-text {
+        & > thead > tr > th.hts-table-column,
+        & > tbody > tr > td.hts-table-cell,
+        & > tbody > tr > td > .hts-table-loading-text {
           font-family: ${theme.font.family.base};
           font-size: ${theme.font.size.xxs};
           line-height: ${theme.line.height.xs};
           color: ${theme.neutralColor.low.dark};
         }
 
-        & > thead > tr > th.hts-table__column,
-        & > tbody > tr > td.hts-table__cell,
-        & > tbody > tr > td.hts-table__cell-action,
-        & > tbody > tr > td.hts-table__cell-collapse,
-        & > tbody > tr > td > .hts-table__loading-text {
+        & > thead > tr > th.hts-table-column,
+        & > tbody > tr > td.hts-table-cell,
+        & > tbody > tr > td.hts-table-cell-action,
+        & > tbody > tr > td.hts-table-cell-collapse,
+        & > tbody > tr > td > .hts-table-loading-text {
           padding: ${theme.spacing.inset.xs};
           border-bottom: ${theme.border.width.xs} solid
             ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[3])};
         }
 
-        & > tbody > tr > td.hts-table__cell-action {
+        & > tbody > tr > td.hts-table-cell-action {
           padding: 0;
           text-align: right;
 
-          & .hts-table__cell-action-menu {
+          & .hts-table-cell-action-menu {
             display: flex;
             flex-direction: column;
           }
 
-          & .hts-table__cell-collapse-arrow {
+          & .hts-table-cell-collapse-arrow {
             transition: 0.15s ease-out;
 
-            &.--hts-active {
+            &.hts-table-cell-collapse-arrow-active {
               transform: rotateX(180deg);
             }
           }
         }
 
-        & > tbody > tr > td.hts-table__cell-collapse {
+        & > tbody > tr > td.hts-table-cell-collapse {
           padding: 0;
           text-align: center;
         }
 
-        & > thead > tr > th.--hts-hidden,
-        & > tbody > tr > td.--hts-hidden {
+        & > thead > tr > th.hst-table-hidden,
+        & > tbody > tr > td.hst-table-hidden {
           display: none;
         }
 
-        & > tbody > tr > td.hts-table__collapse {
+        & > tbody > tr > td.hts-table-collapse {
           transition: 0.3s;
 
-          &:not(.--hts-no-background) {
+          &:not(.hts-table-collapse-background) {
             background-color: ${theme.neutralColor.high.light};
           }
 
-          &.--hts-opened:not(.--hts-no-padding) {
+          &.hts-table-collapse-opened:not(.hts-table-collapse-padding) {
             padding: ${theme.spacing.xxxs};
           }
         }
       }
     }
 
-    & .hts-table__pagination {
+    & .hts-table-pagination {
       padding: ${theme.spacing.inset.xxs};
       background-color: ${theme.neutralColor.high.light};
       border-bottom-left-radius: ${theme.border.radius.sm};
       border-bottom-right-radius: ${theme.border.radius.sm};
     }
 
-    &.--hts-table-size-sm {
-      & > .hts-table__scroller-shadow > .hts-table__scroller > div > table {
-        & > thead > tr > th.hts-table__column,
-        & > tbody > tr > td.hts-table__cell,
-        & > tbody > tr > td.hts-table__cell-action,
-        & > tbody > tr > td.hts-table__cell-collapse,
-        & > tbody > tr > td > .hts-table__loading-text {
+    &.hst-table-size-sm {
+      & > .hts-table-scroller-shadow > .hts-table-scroller > div > table {
+        & > thead > tr > th.hts-table-column,
+        & > tbody > tr > td.hts-table-cell,
+        & > tbody > tr > td.hts-table-cell-action,
+        & > tbody > tr > td.hts-table-cell-collapse,
+        & > tbody > tr > td > .hts-table-loading-text {
           padding: ${theme.spacing.squish.xxs};
         }
       }

--- a/src/pages/ui-components/Table/index.mdx
+++ b/src/pages/ui-components/Table/index.mdx
@@ -354,7 +354,7 @@ Você pode de uma maneira fácil utizar o hook **useObservablePaginated** do **@
 | errorOnRetry  | `function`        | `false`     | `false`                  | Funçao para recarregar caso um erro ocorra                  |
 | total         | `number`          | `false`     | -                        | Total de items, usado para mostrar a mensagem de vazio      |
 | emptyText     | `string`          | `false`     | `Nenhum dado encontrado` | Mensagem de vazio                                           |
-| sort          | `ITableSort`      | `false`     | -                        | Valor atual do sort                                         |
+| sort          | `TableSort`       | `false`     | -                        | Valor atual do sort                                         |
 | onSort        | `function`        | `false`     | -                        | Função chamada ao clicar em uma coluna com `sortableField`. |
 | size          | `Size`            | `false`     | `medium`                 | -                                                           |
 | minWidth      | `number`          | `false`     | -                        | Tamanho da tela que a tabela irá gerar barra de rolagem     |
@@ -365,7 +365,7 @@ Você pode de uma maneira fácil utizar o hook **useObservablePaginated** do **@
 | ------------- | ----------------- | ----------- | ------ | ---------------------------- |
 | sortableField | `string`, `false` | `true`      | -      | Campo referência para o sort |
 | width         | `number`          | `false`     | -      | -                            |
-| align         | `ITableAlign`     | `false`     | `left` | -                            |
+| align         | `TableAlign`      | `false`     | `left` | -                            |
 
 ### Table.Row props
 
@@ -376,10 +376,10 @@ Você pode de uma maneira fácil utizar o hook **useObservablePaginated** do **@
 
 ### Table.Cell props
 
-| prop    | tipo          | obrigatório | padrão | descrição |
-| ------- | ------------- | ----------- | ------ | --------- |
-| align   | `ITableAlign` | `false`     | `left` | -         |
-| colSpan | `number`      | `false`     | -      | -         |
+| prop    | tipo         | obrigatório | padrão | descrição |
+| ------- | ------------ | ----------- | ------ | --------- |
+| align   | `TableAlign` | `false`     | `left` | -         |
+| colSpan | `number`     | `false`     | -      | -         |
 
 ### Table.Option props
 

--- a/src/pages/ui-components/Tabs/Vertical/index.tsx
+++ b/src/pages/ui-components/Tabs/Vertical/index.tsx
@@ -15,6 +15,10 @@ export interface TabsProps extends StyledProp, Omit<React.HTMLAttributes<HTMLDiv
   mountOnEnter?: boolean;
 }
 
+const MIN_HEIGHT_IN_PX = 48;
+const MIN_WIDTH_IN_PX = 80;
+const NEGATIVE_SPACING_IN_PX = -2;
+
 const Tabs = ({ children, value, onChange, destroyOnClose, mountOnEnter, ...rest }: TabsProps) => {
   const childrenProps = useChildrenProps(children, Tab);
   const tabs = useChildrenComponent(children, Tab);
@@ -37,13 +41,13 @@ const Tabs = ({ children, value, onChange, destroyOnClose, mountOnEnter, ...rest
 
   return (
     <div {...rest}>
-      <div ref={labelsRef} className='hst-tabs-vertical__labels'>
+      <div ref={labelsRef} className='hst-tabs-vertical-labels'>
         {childrenProps?.map(({ label, icon, disabled }, index) => (
           <div
             role='button'
             ref={passRefsToArray(index)}
             tabIndex={0}
-            className={cx('hst-tabs-vertical__tab', { '--hst-tabs-vertical-disabled': disabled })}
+            className={cx('hst-tabs-vertical-tab', { 'hst-tabs-vertical-disabled': disabled })}
             onClick={handleTabClick(index)}
             key={label}
             aria-disabled={disabled}
@@ -53,7 +57,7 @@ const Tabs = ({ children, value, onChange, destroyOnClose, mountOnEnter, ...rest
           </div>
         ))}
         <span
-          className='hst-tabs-vertical__slider'
+          className='hst-tabs-vertical-slider'
           style={{
             height: sizes[activeTabValue],
             top: steps[activeTabValue],
@@ -79,30 +83,26 @@ const Tabs = ({ children, value, onChange, destroyOnClose, mountOnEnter, ...rest
   );
 };
 
-const MIN_HEIGHT_IN_PX = 48;
-const MIN_WIDTH_IN_PX = 80;
-const NEGATIVE_SPACING_IN_PX = -2;
-
 export default React.memo(
   styled(Tabs, { label: 'hst-tabs-vertical' })(({ theme }) => {
     return css`
       display: flex;
 
-      .hst-tabs-vertical__labels {
+      .hst-tabs-vertical-labels {
         display: flex;
         margin-right: ${theme.spacing.quarck};
         flex-direction: column;
         position: relative;
       }
 
-      .hst-tabs-vertical__slider {
+      .hst-tabs-vertical-slider {
         position: absolute;
         transition: all 0.2s;
         width: ${theme.border.width.sm};
         background-color: ${theme.brandColor.primary.pure};
       }
 
-      .hst-tabs-vertical__tab {
+      .hst-tabs-vertical-tab {
         display: flex;
         align-items: center;
         line-height: 0;
@@ -129,7 +129,7 @@ export default React.memo(
           outline-offset: ${NEGATIVE_SPACING_IN_PX}px;
         }
 
-        &.--hst-tabs-vertical-disabled {
+        &.hst-tabs-vertical-disabled {
           background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
           opacity: ${theme.opacity.level[6]};
           pointer-events: none;

--- a/src/pages/ui-components/Tabs/index.tsx
+++ b/src/pages/ui-components/Tabs/index.tsx
@@ -30,6 +30,9 @@ const StyledOption = styled.div`
   gap: ${({ theme }) => theme.spacing.inline.nano};
 `;
 
+const NEGATIVE_SPACING_IN_PX = -2;
+const MIN_HEIGHT_IN_PX = 48;
+
 const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mountOnEnter, ...rest }: TabsProps) => {
   const childrenProps = useChildrenProps(children, Tab);
   const tabs = useChildrenComponent(children, Tab);
@@ -167,7 +170,7 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
         {isOverflowed && !isMobile && (
           <IconButton
             disabled={isDisabledLeftArrow}
-            className='hst-tabs__scrollButton'
+            className='hst-tabs-scrollButton'
             size='md'
             onClick={handleScroll('left')}
           >
@@ -177,17 +180,17 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
 
         <div
           ref={parentRef}
-          className='hst-tabs__parent'
+          className='hst-tabs-parent'
           {...(!isMobile && { onScroll: handleScrollArrows })}
           {...(isMobile && { onTouchStart: touchStartHandler, onTouchMove: touchMoveHandler })}
         >
-          <div ref={labelsRef} className='hst-tabs__labels'>
+          <div ref={labelsRef} className='hst-tabs-labels'>
             {childrenProps?.map(({ label, icon, disabled }, index) => (
               <div
                 role='button'
                 ref={passRefsToArray(index)}
                 tabIndex={0}
-                className={cx('hst-tabs__tab', { '--hst_tabs-disabled': disabled })}
+                className={cx('hst-tabs-tab', { 'hst-tabs-disabled': disabled })}
                 onClick={handleTabClick(index)}
                 key={label}
                 aria-disabled={disabled}
@@ -198,7 +201,7 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
             ))}
           </div>
           <span
-            className='hst-tabs__slider'
+            className='hst-tabs-slider'
             style={{
               width: sizes[activeTabValue],
               left: steps[activeTabValue]
@@ -209,7 +212,7 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
         {isOverflowed && !isMobile && (
           <IconButton
             disabled={isDisabledRightArrow}
-            className='hst-tabs__scrollButton'
+            className='hst-tabs-scrollButton'
             size='md'
             onClick={handleScroll('right')}
           >
@@ -233,40 +236,37 @@ const Tabs = ({ children, value, onChange, selectOnMobile, destroyOnClose, mount
   );
 };
 
-const NEGATIVE_SPACING_IN_PX = -2;
-const MIN_HEIGHT_IN_PX = 48;
-
 const TabsWrapper = React.memo(
   styled(Tabs, { label: 'hst-tabs' })(({ theme }) => {
     return css`
       display: flex;
 
-      .hst-tabs__parent {
+      .hst-tabs-parent {
         position: relative;
         overflow-x: hidden;
         overflow-y: hidden;
         padding-bottom: ${theme.spacing.quarck};
       }
 
-      .hst-tabs__labels {
+      .hst-tabs-labels {
         display: flex;
         width: 100%;
         position: relative;
       }
 
-      .hst-tabs__scrollButton {
+      .hst-tabs-scrollButton {
         padding: ${theme.spacing.nano};
         margin: ${theme.spacing.nano};
       }
 
-      .hst-tabs__slider {
+      .hst-tabs-slider {
         position: absolute;
         transition: all 0.2s;
         height: ${theme.border.width.sm};
         background-color: ${theme.brandColor.primary.pure};
       }
 
-      .hst-tabs__tab {
+      .hst-tabs-tab {
         display: flex;
         align-items: center;
         line-height: 0;
@@ -298,7 +298,7 @@ const TabsWrapper = React.memo(
           outline-offset: ${NEGATIVE_SPACING_IN_PX}px;
         }
 
-        &.--hst_tabs-disabled {
+        &.hst-tabs-disabled {
           background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
           opacity: ${theme.opacity.level[6]};
           pointer-events: none;

--- a/src/pages/ui-components/Tag/Category/index.tsx
+++ b/src/pages/ui-components/Tag/Category/index.tsx
@@ -12,7 +12,7 @@ const TagCategory = ({ children, icon, ...rest }: TagCategoryProps) => (
   </span>
 );
 
-export default styled(TagCategory, { label: 'houston-tag-category' })(({ theme }) => {
+export default styled(TagCategory, { label: 'hst-tag-category' })(({ theme }) => {
   return css`
     font-size: ${theme.font.size.xxs};
     font-weight: ${theme.font.weight.regular};

--- a/src/pages/ui-components/Tag/Highlight/index.tsx
+++ b/src/pages/ui-components/Tag/Highlight/index.tsx
@@ -11,8 +11,10 @@ export interface TagHighlightProps extends StyledProp, React.HTMLAttributes<HTML
   variant?: 'outlined' | 'filled';
 }
 
+const MAX_HEIGHT_IN_PX = 22;
+
 const TagHighlight = ({ children, className, variant = 'filled', ...rest }: TagHighlightProps) => (
-  <span className={cx(className, `--${variant}`)} {...rest}>
+  <span className={cx(className, `hst-tag-highlight-variant-${variant}`)} {...rest}>
     {children}
   </span>
 );
@@ -38,31 +40,27 @@ function getColor(theme: HoustonThemeProps, color: string) {
   return result;
 }
 
-const MAX_HEIGHT_IN_PX = 22;
+export default styled(TagHighlight, { label: 'hst-tag-highlight' })(({ theme, color = 'neutralColor.high.medium' }) => {
+  const isDefaultColor = color === 'neutralColor.high.medium';
 
-export default styled(TagHighlight, { label: 'houston-tag-highlight' })(
-  ({ theme, color = 'neutralColor.high.medium' }) => {
-    const isDefaultColor = color === 'neutralColor.high.medium';
+  return css`
+    background-color: ${getColor(theme, color)};
+    border-radius: ${theme.border.radius.pill};
+    padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
+    display: inline-flex;
+    align-items: center;
+    color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
+    line-height: ${theme.line.height.default};
+    font-size: ${theme.font.size.xxs};
+    font-weight: ${theme.font.weight.regular};
+    font-family: ${theme.font.family.base};
+    max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PX)}rem;
 
-    return css`
-      background-color: ${getColor(theme, color)};
-      border-radius: ${theme.border.radius.pill};
-      padding: ${theme.spacing.stack.quarck} ${theme.spacing.inline.xxxs};
-      display: inline-flex;
-      align-items: center;
-      color: ${color === 'brandColor.primary.pure' ? theme.neutralColor.high.pure : theme.neutralColor.low.pure};
-      line-height: ${theme.line.height.default};
-      font-size: ${theme.font.size.xxs};
-      font-weight: ${theme.font.weight.regular};
-      font-family: ${theme.font.family.base};
-      max-height: ${theme.pxToRem(MAX_HEIGHT_IN_PX)}rem;
-
-      &.--outlined {
-        border: ${theme.border.width.xs} solid;
-        border-color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
-        color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
-        background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
-      }
-    `;
-  }
-);
+    &.hst-tag-highlight-variant-outlined {
+      border: ${theme.border.width.xs} solid;
+      border-color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
+      color: ${isDefaultColor ? theme.neutralColor.low.pure : getColor(theme, color)};
+      background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[0])};
+    }
+  `;
+});

--- a/src/pages/ui-components/Tag/__utils/Left/index.tsx
+++ b/src/pages/ui-components/Tag/__utils/Left/index.tsx
@@ -21,7 +21,7 @@ const TagLeft = ({ children, onClick: onClickProp, ...rest }: TagLeftProps) => {
   );
 };
 
-export default styled(TagLeft, { label: 'houston-tag-left' })(({ theme }) => {
+export default styled(TagLeft, { label: 'hst-tag-left' })(({ theme }) => {
   return css`
     border-radius: ${theme.border.radius.circular};
     padding: ${theme.spacing.stack.quarck};

--- a/src/pages/ui-components/Tag/__utils/Right/index.tsx
+++ b/src/pages/ui-components/Tag/__utils/Right/index.tsx
@@ -22,7 +22,7 @@ const TagRight = ({ children, onClick: onClickProp, ...rest }: TagRightProps) =>
   );
 };
 
-export default styled(TagRight, { label: 'houston-tag-right' })(({ theme }) => {
+export default styled(TagRight, { label: 'hst-tag-right' })(({ theme }) => {
   return css`
     border-radius: ${theme.border.radius.circular};
     padding: ${theme.spacing.stack.quarck};

--- a/src/pages/ui-components/Tag/__utils/Text/index.tsx
+++ b/src/pages/ui-components/Tag/__utils/Text/index.tsx
@@ -10,7 +10,7 @@ const Text = ({ children, ...rest }: TextProps) => {
   return <span {...rest}>{children}</span>;
 };
 
-export default styled(Text, { label: 'houston-tag-text' })(({ theme }) => {
+export default styled(Text, { label: 'hst-tag-text' })(({ theme }) => {
   return css`
     font-family: ${theme.font.family.base};
     font-size: ${theme.font.size.xxs};

--- a/src/pages/ui-components/Tag/index.tsx
+++ b/src/pages/ui-components/Tag/index.tsx
@@ -17,16 +17,19 @@ export interface TagProps extends StyledProp, React.HTMLAttributes<HTMLSpanEleme
   onClose?: () => void;
 }
 
+const MIN_HEIGHT_IN_PX = 32;
+
 const Tag = ({ children, disabled, isActive, onClick: onClickProp, className, onClose, ...rest }: TagProps) => {
   return (
     <span
       aria-disabled={disabled}
-      className={cx(className, { '--disabled': disabled }, { '--active': isActive })}
+      className={cx(className, { 'hst-tag-disabled': disabled }, { 'hst-tag-active': isActive })}
       {...(onClickProp && { role: 'button', tabIndex: 0 })}
       onClick={onClickProp}
       {...rest}
     >
       {children}
+
       {onClose && (
         <Right onClick={onClose}>
           <Cancel size='sm' />
@@ -36,9 +39,7 @@ const Tag = ({ children, disabled, isActive, onClick: onClickProp, className, on
   );
 };
 
-const MIN_HEIGHT_IN_PX = 32;
-
-const TagWrapper = styled(Tag, { label: 'houston-tag' })(({ theme }) => {
+const TagWrapper = styled(Tag, { label: 'hst-tag' })(({ theme }) => {
   return css`
     display: inline-flex;
     align-items: center;
@@ -54,7 +55,7 @@ const TagWrapper = styled(Tag, { label: 'houston-tag' })(({ theme }) => {
     outline: none;
 
     :hover,
-    &.--active {
+    &.hst-tag-active {
       background-color: ${theme.brandColor.primary.pure};
       color: ${theme.neutralColor.high.pure};
     }
@@ -63,7 +64,7 @@ const TagWrapper = styled(Tag, { label: 'houston-tag' })(({ theme }) => {
       box-shadow: 0 0 0 ${theme.border.width.sm} ${theme.feedbackColor.informative.pure};
     }
 
-    &.--disabled {
+    &.hst-tag-disabled {
       background-color: ${theme.hexToRgba(theme.neutralColor.low.pure, theme.opacity.level[2])};
       opacity: ${theme.opacity.level[6]};
       pointer-events: none;

--- a/src/pages/ui-components/Toast/ToastBody/index.tsx
+++ b/src/pages/ui-components/Toast/ToastBody/index.tsx
@@ -31,20 +31,21 @@ const ToastBody = ({ className, content, type }: ToastBodyProps) => {
       warning('Toast', `text limit is ${TEXT_MAX_LENGTH} characters`);
     }
   }, [content]);
+
   return (
-    <div role='alertdialog' className={cx(className, `--type-${type}`)}>
-      <span role='img' className='__icon'>
+    <div role='alertdialog' className={cx(className, `hst-toast-body-type-${type}`)}>
+      <span role='img' className='hst-toast-body-icon'>
         {IconsMap[type]}
       </span>
-      <div className='__text'>{truncateText(content, TEXT_MAX_LENGTH)}</div>
-      <span className='__cancel-icon'>
+      <div className='hst-toast-body-text'>{truncateText(content, TEXT_MAX_LENGTH)}</div>
+      <span className='hst-toast-body-cancel-icon'>
         <CancelIcon />
       </span>
     </div>
   );
 };
 
-export default styled(ToastBody, { label: 'houston-toast-body' })`
+export default styled(ToastBody, { label: 'hst-toast-body' })`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
@@ -57,7 +58,7 @@ export default styled(ToastBody, { label: 'houston-toast-body' })`
       width: calc(100vw - ${theme.pxToRem(GUTTER_WIDTH)}rem);
     }
 
-    .__icon {
+    .hst-toast-body-icon {
       line-height: 0;
       margin-right: ${theme.spacing.inline.xxxs};
 
@@ -66,7 +67,7 @@ export default styled(ToastBody, { label: 'houston-toast-body' })`
       }
     }
 
-    .__cancel-icon {
+    .hst-toast-body-cancel-icon {
       line-height: 0;
       margin-left: ${theme.spacing.inline.xxxs};
 
@@ -75,22 +76,22 @@ export default styled(ToastBody, { label: 'houston-toast-body' })`
       }
     }
 
-    &.--type-informative {
+    &.hst-toast-body-type-informative {
       background-color: ${theme.feedbackColor.informative.light};
       border-color: ${theme.feedbackColor.informative.medium};
     }
 
-    &.--type-positive {
+    &.hst-toast-body-type-positive {
       background-color: ${theme.feedbackColor.positive.light};
       border-color: ${theme.feedbackColor.positive.medium};
     }
 
-    &.--type-negative {
+    &.hst-toast-body-type-negative {
       background-color: ${theme.feedbackColor.negative.light};
       border-color: ${theme.feedbackColor.negative.medium};
     }
 
-    &.--type-warning {
+    &.hst-toast-body-type-warning {
       background-color: ${theme.feedbackColor.warning.light};
       border-color: ${theme.feedbackColor.warning.medium};
     }
@@ -100,7 +101,7 @@ export default styled(ToastBody, { label: 'houston-toast-body' })`
       height: ${theme.pxToRem(24)}rem;
     }
 
-    .__text {
+    .hst-toast-body-text {
       font-family: ${theme.font.family.base};
       font-weight: ${theme.font.weight.regular};
       font-size: ${theme.font.size.xs};

--- a/src/pages/ui-components/Tooltip/TooltipBody.tsx
+++ b/src/pages/ui-components/Tooltip/TooltipBody.tsx
@@ -45,7 +45,7 @@ const TooltipBody = ({ className, title }: TooltipBody) => {
   );
 };
 
-export default React.memo(styled(TooltipBody, { label: 'houston-tooltip' })`
+export default React.memo(styled(TooltipBody, { label: 'hst-tooltip' })`
   ${({ theme }) => css`
     padding: ${theme.spacing.inset.xxs};
     border-radius: ${theme.border.radius.xs};

--- a/src/pages/ui-components/Tooltip/styles.ts
+++ b/src/pages/ui-components/Tooltip/styles.ts
@@ -1,70 +1,70 @@
 export const styleContent = (width: number, height: number) => ({
   __html: `
-    .popover[data-popper-placement='top'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='top'] #houston-tooltip-arrow {
       bottom: -4px;
       transform: unset;
     }
 
-    .popover[data-popper-placement='top-start'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='top-start'] #houston-tooltip-arrow {
       bottom: -4px;
       left: 10px !important;
       transform: unset !important;
     }
 
-    .popover[data-popper-placement='top-end'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='top-end'] #houston-tooltip-arrow {
       bottom: -4px;
       left:  ${width - 20}px !important;
       transform: unset !important;
     }
 
-    .popover[data-popper-placement='bottom'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='bottom'] #houston-tooltip-arrow {
       top: -4px;
       transform: unset;
     }
 
-    .popover[data-popper-placement='bottom-start'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='bottom-start'] #houston-tooltip-arrow {
       top: -4px;
       left: 10px !important;
       transform: unset !important;
     }
 
-    .popover[data-popper-placement='bottom-end'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='bottom-end'] #houston-tooltip-arrow {
       top: -4px;
       left:  ${width - 20}px !important;
       transform: unset !important;
     }
 
-    .popover[data-popper-placement='left-start'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='left-start'] #houston-tooltip-arrow {
       transform: unset !important;
       top: 10px !important;
       left: ${width - 4}px;
     }
 
-    .popover[data-popper-placement='left'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='left'] #houston-tooltip-arrow {
       transform: unset !important;
       top: ${height / 2 - 4}px !important;
       left: ${width - 4}px;
     }
 
-    .popover[data-popper-placement='left-end'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='left-end'] #houston-tooltip-arrow {
       transform: unset !important;
       top: ${height - 20}px !important;
       left: ${width - 4}px;
     }
 
-    .popover[data-popper-placement='right-start'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='right-start'] #houston-tooltip-arrow {
       transform: unset !important;
       top: 10px !important;
       right: ${width - 4}px;
     }
 
-    .popover[data-popper-placement='right'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='right'] #houston-tooltip-arrow {
       transform: unset !important;
       top: ${height / 2 - 4}px !important;
       right: ${width - 4}px;
     }
 
-    .popover[data-popper-placement='right-end'] #houston-tooltip-arrow {
+    .hst-popover[data-popper-placement='right-end'] #houston-tooltip-arrow {
       transform: unset !important;
       top: ${height - 20}px !important;
       right: ${width - 4}px;

--- a/src/pages/ui-components/Typography/index.tsx
+++ b/src/pages/ui-components/Typography/index.tsx
@@ -105,11 +105,11 @@ const Typography = React.forwardRef<any, TypographyProps>(({ as: Tag = 'p', clas
     <Tag
       ref={ref}
       className={cx(className, {
-        [`--hst-size-${size}`]: true,
-        [`--hst-line-${lineHeight}`]: true,
-        [`--hst-weight-${weight}`]: true,
-        [`--hst-margin-${margin}`]: !!margin,
-        [`--hst-color-${getColorName(color)}`]: true
+        [`hst-typography-size-${size}`]: true,
+        [`hst-typography-line-${lineHeight}`]: true,
+        [`hst-typography-weight-${weight}`]: true,
+        [`hst-typography-margin-${margin}`]: !!margin,
+        [`hst-typography-color-${getColorName(color)}`]: true
       })}
       {...forwardProps}
     />
@@ -139,13 +139,13 @@ function getColor(theme: HoustonThemeProps, color: TypographyColors) {
   return result;
 }
 
-const TypographyWrapper = styled(Typography, { label: 'houston-typography' })(({ theme }) => {
+const TypographyWrapper = styled(Typography, { label: 'hst-typography-typography' })(({ theme }) => {
   return css`
     margin: 0;
 
     ${Object.keys(theme.font.size).map(
       size => css`
-        &.--hst-size-${size} {
+        &.hst-typography-size-${size} {
           font-size: ${theme.font.size[size]};
         }
       `
@@ -153,7 +153,7 @@ const TypographyWrapper = styled(Typography, { label: 'houston-typography' })(({
 
     ${Object.keys(theme.line.height).map(
       lineHeight => css`
-        &.--hst-line-${lineHeight} {
+        &.hst-typography-line-${lineHeight} {
           line-height: ${theme.line.height[lineHeight]};
         }
       `
@@ -161,7 +161,7 @@ const TypographyWrapper = styled(Typography, { label: 'houston-typography' })(({
 
     ${Object.keys(theme.font.weight).map(
       weight => css`
-        &.--hst-weight-${weight} {
+        &.hst-typography-weight-${weight} {
           font-weight: ${theme.font.weight[weight]};
         }
       `
@@ -169,7 +169,7 @@ const TypographyWrapper = styled(Typography, { label: 'houston-typography' })(({
 
     ${SUPPORTED_COLORS.map(
       color => css`
-        &.--hst-color-${getColorName(color)} {
+        &.hst-typography-color-${getColorName(color)} {
           color: ${getColor(theme, color)};
         }
       `
@@ -177,7 +177,7 @@ const TypographyWrapper = styled(Typography, { label: 'houston-typography' })(({
 
     ${SUPPORTED_MARGINS.map(
       margin => css`
-        &.--hst-margin-${margin} {
+        &.hst-typography-margin-${margin} {
           margin-bottom: ${theme.spacing[margin]};
         }
       `


### PR DESCRIPTION
Oi.

Recentemente tivemos um probleminha chato com sobrescrita de CSS em nossas classes por elas serem "muito genéricas" e utilizarem o padrão BEM (em alguns casos). Isso acabou quebrando os estilos dos componentes em algumas aplicações.

Alguns casos bem comuns que nos prejudicaram: `--isActive`, `__container`, `& > .__wrapper`, etc...

Nós começamos a inserir o prefixo `hst-` no começo de cada classe dos nossos componentes, mas não foi o suficiente e gera muita dúvida de como escrever as classes internas, por exemplo:

- `hst-dialog .hst-dialog__header .hst-dialog-header__icon` ou `hst-dialog .hst-dialog__header .hst-dialog__header-icon`?
- `hst-dialog-footer-logo` ou `hst-dialog-footer__logo`?

Enfim, são vários casos que estávamos nos perdendo e cada um escrevendo de uma forma. Para reduzir as margens de "erros" e despadronização vamos definir um padrão mais simples, apenas com hífens (-) para separar os níveis. Por exemplo:

- `hst-dialog-header`,
- `hst-dialog-header-icon`,
- `hst-dialog-footer-logo`
- `hst-dialog-header.hst-dialog-header-variant-outline`.

(Composto por prefixo: `hst-`, nome do componente: `footer`, filho/seção/elemento/modificador: `logo` = `hst-footer-logo`).

**Isto inclui os "modificadores" também (`.hst-button-variant-outline`).**

Em resumo não precisamos mais gastar esforços pensando em como escrever nome de classes. Este PR padroniza TODAS as classes para este novo formato.

Obrigado @miguelaugl pela sugestão e pelos questionamentos.