### PR TITLE
fix: flex-grow on the drawer title to take all the available area

### DIFF
--- a/src/pages/ui-components/Drawer/Header/index.tsx
+++ b/src/pages/ui-components/Drawer/Header/index.tsx
@@ -64,6 +64,10 @@ export default React.memo(styled(DrawerHeader, { label: 'hst-drawer-header' })`
         padding: ${theme.spacing.inset.xs};
       }
 
+      .hst-drawer-header-title {
+        flex-grow: 1;
+      }
+
       .hst-drawer-header-close {
         margin-left: ${theme.spacing.inline.xxs};
       }


### PR DESCRIPTION
O drawer estava com o espaço limitado, fiz o fix para aumentar a rea útil:

(Laranja só para deixar visível)

Antes:
![image](https://user-images.githubusercontent.com/89180/194874168-1fa6eab3-e046-429e-823b-25ea8b18180a.png)


Depois:
![image](https://user-images.githubusercontent.com/89180/194874498-48f3feb8-eaf7-45d7-9686-2cda62cdc655.png)
